### PR TITLE
Add useful converters to imagej-common

### DIFF
--- a/src/main/java/net/imagej/converters/ConvertIntArrayToDimensions.java
+++ b/src/main/java/net/imagej/converters/ConvertIntArrayToDimensions.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.converters;
+
+import org.scijava.convert.Converter;
+
+import net.imglib2.Dimensions;
+
+/**
+ * 
+ * Interface to describe Converters from native int[] arrays to Dimensions
+ * 
+ * @author Christian Dietz, University of Konstanz
+ *
+ * @param <D>
+ *            resulting Dimensions type
+ */
+public interface ConvertIntArrayToDimensions<D extends Dimensions> extends
+		Converter<int[], D> {
+	// NB: Marker interface
+}

--- a/src/main/java/net/imagej/converters/ConvertIntArrayToFinalInterval.java
+++ b/src/main/java/net/imagej/converters/ConvertIntArrayToFinalInterval.java
@@ -1,0 +1,88 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.converters;
+
+import net.imglib2.Dimensions;
+import net.imglib2.FinalInterval;
+
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.ConversionRequest;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Converter from native int[] array to Dimensions
+ * 
+ * Christian Dietz, University of Konstanz
+ */
+@Plugin(type = ConvertLongArrayToDimensions.class)
+public class ConvertIntArrayToFinalInterval extends
+		AbstractConverter<int[], FinalInterval> implements
+		ConvertIntArrayToDimensions<FinalInterval> {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T convert(Object src, Class<T> dest) {
+		final int[] in = (int[]) src;
+		final long[] out = new long[in.length];
+		
+		for(int i = 0; i < in.length; i++){
+			out[i] = in[i];
+		}
+		
+		return (T) new FinalInterval(out);
+	}
+
+	@Override
+	public Class<FinalInterval> getOutputType() {
+		return FinalInterval.class;
+	}
+
+	@Override
+	public Class<int[]> getInputType() {
+		return int[].class;
+	}
+
+	@Override
+	public boolean canConvert(Object src, Class<?> dest) {
+		return canConvert(new ConversionRequest(src.getClass(), dest));
+	}
+
+	@Override
+	public boolean canConvert(ConversionRequest req) {
+		return supports(req);
+	}
+
+	@Override
+	public boolean supports(ConversionRequest request) {
+		return request.sourceClass() == int[].class
+				&& Dimensions.class.isAssignableFrom(request.destClass());
+	}
+}

--- a/src/main/java/net/imagej/converters/ConvertLongArrayToDimensions.java
+++ b/src/main/java/net/imagej/converters/ConvertLongArrayToDimensions.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.converters;
+
+import org.scijava.convert.Converter;
+
+import net.imglib2.Dimensions;
+
+/**
+ * 
+ * Interface to describe Converters from native long[] arrays to Dimensions
+ * 
+ * @author Christian Dietz, University of Konstanz
+ *
+ * @param <D>
+ *            resulting Dimensions type
+ */
+public interface ConvertLongArrayToDimensions<D extends Dimensions> extends
+		Converter<long[], D> {
+	// NB: Marker interface
+}

--- a/src/main/java/net/imagej/converters/ConvertLongArrayToFinalInterval.java
+++ b/src/main/java/net/imagej/converters/ConvertLongArrayToFinalInterval.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.converters;
+
+import net.imglib2.Dimensions;
+import net.imglib2.FinalInterval;
+
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.ConversionRequest;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Converter from native long[] array to Dimensions
+ * 
+ * Christian Dietz, University of Konstanz
+ */
+@Plugin(type = ConvertLongArrayToDimensions.class)
+public class ConvertLongArrayToFinalInterval extends
+		AbstractConverter<long[], FinalInterval> implements
+		ConvertLongArrayToDimensions<FinalInterval> {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T convert(Object src, Class<T> dest) {
+		long[] input = (long[]) src;
+		return (T) new FinalInterval(input);
+	}
+
+	@Override
+	public Class<FinalInterval> getOutputType() {
+		return FinalInterval.class;
+	}
+
+	@Override
+	public Class<long[]> getInputType() {
+		return long[].class;
+	}
+
+	@Override
+	public boolean canConvert(Object src, Class<?> dest) {
+		return canConvert(new ConversionRequest(src.getClass(), dest));
+	}
+
+	@Override
+	public boolean canConvert(ConversionRequest req) {
+		return supports(req);
+	}
+
+	@Override
+	public boolean supports(ConversionRequest request) {
+		return request.sourceClass() == long[].class
+				&& Dimensions.class.isAssignableFrom(request.destClass());
+	}
+}

--- a/src/main/java/net/imagej/converters/ConvertRAIToIterableInterval.java
+++ b/src/main/java/net/imagej/converters/ConvertRAIToIterableInterval.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.converters;
+
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.view.Views;
+
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Converts RandomAccessibleInterval to IterableInterval using Views
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+@SuppressWarnings("rawtypes")
+@Plugin(type = Converter.class)
+public class ConvertRAIToIterableInterval extends
+		AbstractConverter<RandomAccessibleInterval, IterableInterval> implements
+		Converter<RandomAccessibleInterval, IterableInterval> {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T convert(Object src, Class<T> dest) {
+		return (T) Views.iterable((RandomAccessibleInterval<T>) src);
+	}
+
+	@Override
+	public Class<IterableInterval> getOutputType() {
+		return IterableInterval.class;
+	}
+
+	@Override
+	public Class<RandomAccessibleInterval> getInputType() {
+		return RandomAccessibleInterval.class;
+	}
+
+}

--- a/src/test/java/net/imagej/converters/ConvertArrayToFinalIntervalTest.java
+++ b/src/test/java/net/imagej/converters/ConvertArrayToFinalIntervalTest.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.converters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import net.imglib2.Dimensions;
+
+import org.junit.Test;
+import org.scijava.convert.Converter;
+
+/**
+ * Tests converters from native java arrays to FinalIntervals
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+public class ConvertArrayToFinalIntervalTest {
+
+	@Test
+	public void convertLongArrayToDimensionsTest() {
+
+		long[] dims = new long[] { 1, 2, 3 };
+
+		final Converter<long[], ? extends Dimensions> converter = new ConvertLongArrayToFinalInterval();
+		assertTrue(converter.canConvert(dims, Dimensions.class));
+
+		final Dimensions dimensions = converter.convert(dims, Dimensions.class);
+
+		assertTrue(dimensions != null);
+
+		for (int d = 0; d < dimensions.numDimensions(); d++) {
+			assertEquals(dims[d], dimensions.dimension(d));
+		}
+
+	}
+
+	@Test
+	public void convertIntArrayToDimensionsTest() {
+
+		int[] dims = new int[] { 1, 2, 3 };
+
+		final Converter<int[], ? extends Dimensions> converter = new ConvertIntArrayToFinalInterval();
+		assertTrue(converter.canConvert(dims, Dimensions.class));
+
+		final Dimensions dimensions = converter.convert(dims, Dimensions.class);
+
+		assertTrue(dimensions != null);
+
+		for (int d = 0; d < dimensions.numDimensions(); d++) {
+			assertEquals(dims[d], dimensions.dimension(d));
+		}
+
+	}
+}

--- a/src/test/java/net/imagej/converters/ConvertRAIToIterableIntervalTest.java
+++ b/src/test/java/net/imagej/converters/ConvertRAIToIterableIntervalTest.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.converters;
+
+import static org.junit.Assert.assertTrue;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.view.Views;
+
+import org.junit.Test;
+import org.scijava.convert.Converter;
+
+/**
+ * Tests conversion between RandomAccessibleInterval and IterableInterval
+ * 
+ * @author Christian Dietz, University of Konstanz
+ */
+public class ConvertRAIToIterableIntervalTest {
+
+	@Test
+	public void convertRaitoIterableIntervalTest() {
+
+		// we need a Rai
+		final RandomAccessibleInterval<ByteType> rai = Views.subsample(
+				ArrayImgs.bytes(10, 10, 10), 2);
+
+		// Test if converter can convert
+		@SuppressWarnings("rawtypes")
+		final Converter<RandomAccessibleInterval, IterableInterval> converter = new ConvertRAIToIterableInterval();
+		assertTrue(converter.canConvert(rai, IterableInterval.class));
+
+		// Test if result is non-null
+		assertTrue(converter.convert(rai, IterableInterval.class) != null);
+
+	}
+}


### PR DESCRIPTION
This PR adds the following SciJava `Converter`s to imagej-common:

* Convert from `int[]` to `FinalInterval`
* Convert from `long[]` to `FinalInterval`
* Convert from `RandomAccessibleInterval` to `IterableInterval`

More converters will be added in the near future, but these ones we need for Ops now:
https://github.com/imagej/imagej-ops/pull/123