### PR TITLE
DefaultImageDisplay: add readable toString

### DIFF
--- a/src/main/java/net/imagej/display/DefaultImageDisplay.java
+++ b/src/main/java/net/imagej/display/DefaultImageDisplay.java
@@ -710,4 +710,8 @@ public class DefaultImageDisplay extends AbstractDisplay<DataView> implements
 		combinedInterval.clear();
 	}
 
+	@Override
+	public String toString() {
+		return getName();
+	}
 }


### PR DESCRIPTION
Fixes an issue when showing a selection dialog for `ImagePlus` parameters in a Swing UI. In that case, the dropdown for selecting an image gets populated with `toString` representations of the usable objects (`ImageDisplay` among others).