### PR TITLE
Deprecate net.imagej.table.* in favour of org.scijava.table.*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>21.0.0</version>
+		<version>23.1.1</version>
 		<relativePath />
 	</parent>
 
 	<groupId>net.imagej</groupId>
 	<artifactId>imagej-common</artifactId>
-	<version>0.26.2-SNAPSHOT</version>
+	<version>0.27.0-SNAPSHOT</version>
 
 	<name>ImageJ Common</name>
 	<description>This library contains ImageJ's core image data model, based on ImgLib2. It is the primary mechanism by which image data is managed internally by ImageJ2. This component also provides the corresponding core image display logic for user interfaces.</description>
@@ -108,6 +108,11 @@
 			<url>http://imagej.net/Wayne_Rasband</url>
 			<properties><id>rasband</id></properties>
 		</contributor>
+		<contributor>
+			<name>Jan Eglinger</name>
+			<url>http://imagej.net/Eglinger</url>
+			<properties><id>imagejan</id></properties>
+		</contributor>
 	</contributors>
 
 	<mailingLists>
@@ -144,7 +149,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
 
-		<scijava-common.version>2.73.0</scijava-common.version>
+		<scijava-table.version>0.2.0</scijava-table.version>
 	</properties>
 
 	<repositories>
@@ -169,6 +174,12 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-common</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-table</artifactId>
+			<version>${scijava-table.version}</version>
 		</dependency>
 
 		<!-- Third party dependencies -->

--- a/src/main/java/net/imagej/table/AbstractTable.java
+++ b/src/main/java/net/imagej/table/AbstractTable.java
@@ -41,7 +41,10 @@ import org.scijava.util.SizableArrayList;
  * 
  * @author Curtis Rueden
  * @param <T> The type of data stored in the table.
+ * 
+ * @deprecated use {@link org.scijava.table.AbstractTable}
  */
+@Deprecated
 public abstract class AbstractTable<C extends Column<? extends T>, T> extends
 	SizableArrayList<C> implements Table<C, T>
 {

--- a/src/main/java/net/imagej/table/BoolColumn.java
+++ b/src/main/java/net/imagej/table/BoolColumn.java
@@ -37,7 +37,10 @@ import org.scijava.util.BoolArray;
  * Efficient implementation of {@link Column} for {@code boolean} primitives.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.BoolColumn}
  */
+@Deprecated
 public class BoolColumn extends BoolArray implements
 	PrimitiveColumn<boolean[], Boolean>
 {

--- a/src/main/java/net/imagej/table/BoolTable.java
+++ b/src/main/java/net/imagej/table/BoolTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * A table of {@code boolean} values.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.BoolTable}
  */
+@Deprecated
 public interface BoolTable extends Table<BoolColumn, Boolean> {
 
 	/** Gets the value of the given table cell. */

--- a/src/main/java/net/imagej/table/ByteColumn.java
+++ b/src/main/java/net/imagej/table/ByteColumn.java
@@ -37,7 +37,10 @@ import org.scijava.util.ByteArray;
  * Efficient implementation of {@link Column} for {@code byte} primitives.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.ByteColumn}
  */
+@Deprecated
 public class ByteColumn extends ByteArray implements
 	PrimitiveColumn<byte[], Byte>
 {

--- a/src/main/java/net/imagej/table/ByteTable.java
+++ b/src/main/java/net/imagej/table/ByteTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * A table of byte-precision integer values.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.ByteTable}
  */
+@Deprecated
 public interface ByteTable extends Table<ByteColumn, Byte> {
 
 	/** Gets the value of the given table cell. */

--- a/src/main/java/net/imagej/table/CharColumn.java
+++ b/src/main/java/net/imagej/table/CharColumn.java
@@ -37,7 +37,10 @@ import org.scijava.util.CharArray;
  * Efficient implementation of {@link Column} for {@code char} primitives.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.CharColumn}
  */
+@Deprecated
 public class CharColumn extends CharArray implements
 	PrimitiveColumn<char[], Character>
 {

--- a/src/main/java/net/imagej/table/CharTable.java
+++ b/src/main/java/net/imagej/table/CharTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * A table of {@code char} values.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.CharTable}
  */
+@Deprecated
 public interface CharTable extends Table<CharColumn, Character> {
 
 	/** Gets the value of the given table cell. */

--- a/src/main/java/net/imagej/table/Column.java
+++ b/src/main/java/net/imagej/table/Column.java
@@ -40,7 +40,10 @@ import org.scijava.util.Sizable;
  *
  * @author Curtis Rueden
  * @param <T> The type of data stored in the table.
+ * 
+ * @deprecated use {@link org.scijava.table.Column}
  */
+@Deprecated
 public interface Column<T> extends List<T>, Sizable {
 
 	/** Gets the header of this column. */

--- a/src/main/java/net/imagej/table/DefaultBoolTable.java
+++ b/src/main/java/net/imagej/table/DefaultBoolTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * Default implementation of {@link BoolTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultBoolTable}
  */
+@Deprecated
 public class DefaultBoolTable extends AbstractTable<BoolColumn, Boolean>
 	implements BoolTable
 {

--- a/src/main/java/net/imagej/table/DefaultByteTable.java
+++ b/src/main/java/net/imagej/table/DefaultByteTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * Default implementation of {@link ByteTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultByteTable}
  */
+@Deprecated
 public class DefaultByteTable extends AbstractTable<ByteColumn, Byte>
 	implements ByteTable
 {

--- a/src/main/java/net/imagej/table/DefaultCharTable.java
+++ b/src/main/java/net/imagej/table/DefaultCharTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * Default implementation of {@link CharTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultCharTable}
  */
+@Deprecated
 public class DefaultCharTable extends AbstractTable<CharColumn, Character>
 	implements CharTable
 {

--- a/src/main/java/net/imagej/table/DefaultColumn.java
+++ b/src/main/java/net/imagej/table/DefaultColumn.java
@@ -38,7 +38,10 @@ import org.scijava.util.ObjectArray;
  * 
  * @author Curtis Rueden
  * @param <T> The type of data stored in the table.
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultColumn}
  */
+@Deprecated
 public class DefaultColumn<T> extends ObjectArray<T> implements Column<T> {
 
 	/** The type of this column. */

--- a/src/main/java/net/imagej/table/DefaultFloatTable.java
+++ b/src/main/java/net/imagej/table/DefaultFloatTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * Default implementation of {@link FloatTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultFloatTable}
  */
+@Deprecated
 public class DefaultFloatTable extends AbstractTable<FloatColumn, Float>
 	implements FloatTable
 {

--- a/src/main/java/net/imagej/table/DefaultGenericTable.java
+++ b/src/main/java/net/imagej/table/DefaultGenericTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * Default implementation of {@link GenericTable}.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultGenericTable}
  */
+@Deprecated
 public class DefaultGenericTable extends
 	AbstractTable<Column<? extends Object>, Object> implements GenericTable
 {

--- a/src/main/java/net/imagej/table/DefaultIntTable.java
+++ b/src/main/java/net/imagej/table/DefaultIntTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * Default implementation of {@link IntTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultIntTable}
  */
+@Deprecated
 public class DefaultIntTable extends AbstractTable<IntColumn, Integer>
 	implements IntTable
 {

--- a/src/main/java/net/imagej/table/DefaultLongTable.java
+++ b/src/main/java/net/imagej/table/DefaultLongTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * Default implementation of {@link LongTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultLongTable}
  */
+@Deprecated
 public class DefaultLongTable extends AbstractTable<LongColumn, Long>
 	implements LongTable
 {

--- a/src/main/java/net/imagej/table/DefaultResultsTable.java
+++ b/src/main/java/net/imagej/table/DefaultResultsTable.java
@@ -37,12 +37,16 @@ import net.imagej.axis.AxisType;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.real.DoubleType;
 
+import org.scijava.table.AbstractTable;
+import org.scijava.table.DefaultDoubleTable;
+import org.scijava.table.DoubleColumn;
+
 /**
  * Default implementation of {@link ResultsTable}.
  * 
  * @author Curtis Rueden
  */
-public class DefaultResultsTable extends AbstractTable<DoubleColumn, Double>
+public class DefaultResultsTable extends DefaultDoubleTable
 	implements ResultsTable
 {
 
@@ -67,13 +71,6 @@ public class DefaultResultsTable extends AbstractTable<DoubleColumn, Double>
 			new ImgPlus<>(img, name, axes);
 		// TODO: Once ImgPlus has a place for row & column labels, add those too.
 		return imgPlus;
-	}
-
-	// -- Internal methods --
-
-	@Override
-	protected DoubleColumn createColumn(final String header) {
-		return new DoubleColumn(header);
 	}
 
 }

--- a/src/main/java/net/imagej/table/DefaultShortTable.java
+++ b/src/main/java/net/imagej/table/DefaultShortTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * Default implementation of {@link ShortTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultShortTable}
  */
+@Deprecated
 public class DefaultShortTable extends AbstractTable<ShortColumn, Short>
 	implements ShortTable
 {

--- a/src/main/java/net/imagej/table/DefaultTableDisplay.java
+++ b/src/main/java/net/imagej/table/DefaultTableDisplay.java
@@ -36,10 +36,13 @@ import org.scijava.display.Display;
 import org.scijava.plugin.Plugin;
 
 /**
- * Default display for {@link Table}s, including {@link ResultsTable}s.
+ * Default display for (deprecated) {@link Table}s, excluding {@link ResultsTable}s.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated use {@link org.scijava.table.DefaultTableDisplay}
  */
+@Deprecated
 @Plugin(type = Display.class)
 public class DefaultTableDisplay extends AbstractDisplay<Table<?, ?>> implements
 	TableDisplay
@@ -54,71 +57,17 @@ public class DefaultTableDisplay extends AbstractDisplay<Table<?, ?>> implements
 
 	@Override
 	public boolean canDisplay(final Class<?> c) {
-		if (c == double[].class || c == double[][].class) return true;
 		return super.canDisplay(c);
 	}
 
 	@Override
 	public void display(final Object o) {
-		// wrap 1D array as results table
-		if (o instanceof double[]) {
-			display(wrapArrayAsTable(new double[][] { (double[]) o }));
-			return;
-		}
-		// wrap 2D array as results table
-		if (o instanceof double[][]) {
-			display(wrapArrayAsTable((double[][]) o));
-			return;
-		}
-
 		super.display(o);
 	}
 
 	@Override
 	public boolean isDisplaying(final Object o) {
-		if (super.isDisplaying(o)) return true;
-
-		// check for wrapped arrays
-		if (o instanceof double[]) {
-			arrayEqualsTable(new double[][] {(double[]) o});
-		}
-		if (o instanceof double[][]) {
-			arrayEqualsTable((double[][]) o);
-		}
-
-		return false;
-	}
-
-	// -- Helper methods --
-
-	private ResultsTable wrapArrayAsTable(final double[][] array) {
-		final ResultsTable table = new DefaultResultsTable();
-		int rowCount = 0;
-		for (int d = 0; d < array.length; d++) {
-			final DoubleColumn column = new DoubleColumn();
-			column.setArray(array[d]);
-			table.add(column);
-			if (rowCount < array[d].length) rowCount = array[d].length;
-		}
-		table.setRowCount(rowCount);
-		return table;
-	}
-
-	private boolean arrayEqualsTable(final double[][] array) {
-		for (final Table<?, ?> table : this) {
-			if (!(table instanceof ResultsTable)) continue;
-			final ResultsTable resultsTable = (ResultsTable) table;
-			if (array.length != resultsTable.getColumnCount()) continue;
-			boolean equal = true;
-			for (int c = 0; c < array.length; c++) {
-				if (array[c] != resultsTable.get(c).getArray()) {
-					equal = false;
-					break;
-				}
-			}
-			return equal;
-		}
-		return false;
+		return(super.isDisplaying(o));
 	}
 
 }

--- a/src/main/java/net/imagej/table/DefaultTableService.java
+++ b/src/main/java/net/imagej/table/DefaultTableService.java
@@ -7,6 +7,9 @@ import net.imagej.Dataset;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
 import org.scijava.service.Service;
+import org.scijava.table.Table;
+
+// TODO keep deprecated version of this with net.imagej.table.Table ?
 
 @Plugin(type = Service.class)
 public class DefaultTableService extends AbstractService implements TableService{

--- a/src/main/java/net/imagej/table/DoubleColumn.java
+++ b/src/main/java/net/imagej/table/DoubleColumn.java
@@ -37,7 +37,10 @@ import org.scijava.util.DoubleArray;
  * Efficient implementation of {@link Column} for {@code double} primitives.
  *
  * @author Curtis Rueden
+ * 
+ * @deprecated use {@link org.scijava.table.DoubleColumn}
  */
+@Deprecated
 public class DoubleColumn extends DoubleArray implements
 	PrimitiveColumn<double[], Double>
 {

--- a/src/main/java/net/imagej/table/FloatColumn.java
+++ b/src/main/java/net/imagej/table/FloatColumn.java
@@ -37,7 +37,10 @@ import org.scijava.util.FloatArray;
  * Efficient implementation of {@link Column} for {@code float} primitives.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.FloatColumn}
  */
+@Deprecated
 public class FloatColumn extends FloatArray implements 
 	PrimitiveColumn<float[], Float>
 {

--- a/src/main/java/net/imagej/table/FloatTable.java
+++ b/src/main/java/net/imagej/table/FloatTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * A table of float-precision floating point values.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.FloatTable}
  */
+@Deprecated
 public interface FloatTable extends Table<FloatColumn, Float> {
 
 	/** Gets the value of the given table cell. */

--- a/src/main/java/net/imagej/table/GenericColumn.java
+++ b/src/main/java/net/imagej/table/GenericColumn.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * A column that can consist of any {@link Object}s.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated use {@link org.scijava.table.GenericColumn}
  */
+@Deprecated
 public class GenericColumn extends DefaultColumn<Object> {
 
 	public GenericColumn() {

--- a/src/main/java/net/imagej/table/GenericTable.java
+++ b/src/main/java/net/imagej/table/GenericTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * A flexible table capable of storing any values as {@link Object}s.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated use {@link org.scijava.table.GenericTable}
  */
+@Deprecated
 public interface GenericTable extends Table<Column<? extends Object>, Object> {
 	// NB: No implementation needed.
 }

--- a/src/main/java/net/imagej/table/IntColumn.java
+++ b/src/main/java/net/imagej/table/IntColumn.java
@@ -37,7 +37,10 @@ import org.scijava.util.IntArray;
  * Efficient implementation of {@link Column} for {@code int} primitives.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.IntColumn}
  */
+@Deprecated
 public class IntColumn extends IntArray implements
 	PrimitiveColumn<int[], Integer>
 {

--- a/src/main/java/net/imagej/table/IntTable.java
+++ b/src/main/java/net/imagej/table/IntTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * A table of int-precision integer values.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.IntTable}
  */
+@Deprecated
 public interface IntTable extends Table<IntColumn, Integer> {
 
 	/** Gets the value of the given table cell. */

--- a/src/main/java/net/imagej/table/LongColumn.java
+++ b/src/main/java/net/imagej/table/LongColumn.java
@@ -37,7 +37,10 @@ import org.scijava.util.LongArray;
  * Efficient implementation of {@link Column} for {@code long} primitives.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.LongColumn}
  */
+@Deprecated
 public class LongColumn extends LongArray implements
 	PrimitiveColumn<long[], Long>
 {

--- a/src/main/java/net/imagej/table/LongTable.java
+++ b/src/main/java/net/imagej/table/LongTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * A table of long-precision integer values.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.LongTable}
  */
+@Deprecated
 public interface LongTable extends Table<LongColumn, Long> {
 
 	/** Gets the value of the given table cell. */

--- a/src/main/java/net/imagej/table/PrimitiveColumn.java
+++ b/src/main/java/net/imagej/table/PrimitiveColumn.java
@@ -40,7 +40,10 @@ import org.scijava.util.PrimitiveArray;
  * @author Alison Walter
  * @param <ArrayType> Type of the primitive array; e.g., {@code double[]}.
  * @param <BaseType> Boxed type of the array element; e.g., {@code Double}.
+ * 
+ * @deprecated use {@link org.scijava.table.PrimitiveColumn}
  */
+@Deprecated
 public interface PrimitiveColumn<ArrayType, BaseType> extends Column<BaseType>,
 	PrimitiveArray<ArrayType, BaseType>
 {

--- a/src/main/java/net/imagej/table/ResultsTable.java
+++ b/src/main/java/net/imagej/table/ResultsTable.java
@@ -31,6 +31,8 @@
 
 package net.imagej.table;
 
+import org.scijava.table.DoubleTable;
+
 import net.imagej.ImgPlus;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -39,17 +41,7 @@ import net.imglib2.type.numeric.real.DoubleType;
  * 
  * @author Curtis Rueden
  */
-public interface ResultsTable extends Table<DoubleColumn, Double> {
-
-	/** Gets the value of the given table cell. */
-	default double getValue(final int col, final int row) {
-		return get(col).getValue(row);
-	}
-
-	/** Sets the value of the given table cell. */
-	default void setValue(final int col, final int row, final double value) {
-		get(col).setValue(row, value);
-	}
+public interface ResultsTable extends DoubleTable {
 
 	/** Wraps the results table in an ImgLib {@link net.imglib2.img.Img}. */
 	ImgPlus<DoubleType> img();

--- a/src/main/java/net/imagej/table/ShortColumn.java
+++ b/src/main/java/net/imagej/table/ShortColumn.java
@@ -37,7 +37,10 @@ import org.scijava.util.ShortArray;
  * Efficient implementation of {@link Column} for {@code short} primitives.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.ShortColumn}
  */
+@Deprecated
 public class ShortColumn extends ShortArray implements
 	PrimitiveColumn<short[], Short>
 {

--- a/src/main/java/net/imagej/table/ShortTable.java
+++ b/src/main/java/net/imagej/table/ShortTable.java
@@ -35,7 +35,10 @@ package net.imagej.table;
  * A table of short-precision integer values.
  *
  * @author Alison Walter
+ * 
+ * @deprecated use {@link org.scijava.table.ShortTable}
  */
+@Deprecated
 public interface ShortTable extends Table<ShortColumn, Short> {
 
 	/** Gets the value of the given table cell. */

--- a/src/main/java/net/imagej/table/Table.java
+++ b/src/main/java/net/imagej/table/Table.java
@@ -42,7 +42,10 @@ import java.util.ListIterator;
  * @author Curtis Rueden
  * @param <C> The type of column used by the table.
  * @param <T> The type of data stored in the table.
+ * 
+ * @deprecated use {@link org.scijava.table.Table}
  */
+@Deprecated
 public interface Table<C extends Column<? extends T>, T> extends List<C> {
 
 	/** Gets the number of columns in the table. */

--- a/src/main/java/net/imagej/table/TableDisplay.java
+++ b/src/main/java/net/imagej/table/TableDisplay.java
@@ -37,7 +37,10 @@ import org.scijava.display.Display;
  * Interface for {@link Table} {@link Display}s.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated replaced by {@link org.scijava.table.TableDisplay}
  */
+@Deprecated
 public interface TableDisplay extends Display<Table<?, ?>> {
 	// This interface intentionally left blank.
 }

--- a/src/main/java/net/imagej/table/TableLoader.java
+++ b/src/main/java/net/imagej/table/TableLoader.java
@@ -50,7 +50,10 @@ import java.net.URL;
  * 
  * @author Barry DeZonia
  * @author Wayne Rasband
+ * 
+ * @deprecated replaced by {@link org.scijava.table.TableLoader}
  */
+@Deprecated
 public class TableLoader {
 
 	// -- instance variables --

--- a/src/main/java/net/imagej/table/TableService.java
+++ b/src/main/java/net/imagej/table/TableService.java
@@ -8,6 +8,9 @@ import net.imagej.Dataset;
 import net.imagej.ImageJService;
 
 import org.scijava.service.Service;
+import org.scijava.table.Table;
+
+//TODO keep deprecated version of this with net.imagej.table.Table ?
 
 /**
  * {@link Service} for working with {@link Table}s.

--- a/src/main/java/net/imagej/table/process/ResultsPostprocessor.java
+++ b/src/main/java/net/imagej/table/process/ResultsPostprocessor.java
@@ -52,7 +52,10 @@ import org.scijava.util.ClassUtils;
  * for a nicer UI experience.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated replaced by {@link org.scijava.table.process.ResultsPostprocessor}
  */
+@Deprecated
 @Plugin(type = PostprocessorPlugin.class,
 	priority = Priority.VERY_LOW_PRIORITY + 1)
 public class ResultsPostprocessor extends AbstractPostprocessorPlugin {

--- a/src/main/java/net/imagej/ui/viewer/table/AbstractTableDisplayViewer.java
+++ b/src/main/java/net/imagej/ui/viewer/table/AbstractTableDisplayViewer.java
@@ -41,7 +41,10 @@ import org.scijava.ui.viewer.AbstractDisplayViewer;
  * Implements the UI-independent elements of a {@link Table} viewer.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated replaced by {@link org.scijava.ui.viewer.table.AbstractTableDisplayViewer}
  */
+@Deprecated
 public abstract class AbstractTableDisplayViewer extends
 	AbstractDisplayViewer<Table<?, ?>> implements TableDisplayViewer
 {

--- a/src/main/java/net/imagej/ui/viewer/table/TableDisplayPanel.java
+++ b/src/main/java/net/imagej/ui/viewer/table/TableDisplayPanel.java
@@ -41,7 +41,10 @@ import org.scijava.ui.viewer.DisplayPanel;
  * {@link Table}s.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated replaced by {@link org.scijava.ui.viewer.table.TableDisplayPanel}
  */
+@Deprecated
 public interface TableDisplayPanel extends DisplayPanel {
 
 	@Override

--- a/src/main/java/net/imagej/ui/viewer/table/TableDisplayViewer.java
+++ b/src/main/java/net/imagej/ui/viewer/table/TableDisplayViewer.java
@@ -40,7 +40,10 @@ import org.scijava.ui.viewer.DisplayViewer;
  * A display viewer for a display of {@link Table}s.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated replaced by {@link org.scijava.ui.viewer.table.TableDisplayViewer}
  */
+@Deprecated
 public interface TableDisplayViewer extends DisplayViewer<Table<?, ?>> {
 
 	@Override

--- a/src/test/java/net/imagej/table/DefaultBoolTableTest.java
+++ b/src/test/java/net/imagej/table/DefaultBoolTableTest.java
@@ -42,7 +42,10 @@ import org.junit.Test;
  * Tests {@link DefaultBoolTable}.
  * 
  * @author Alison Walter
+ * 
+ * @deprecated replaced by {@link org.scijava.table.DefaultBoolTableTest}
  */
+@Deprecated
 public class DefaultBoolTableTest {
 
 	private static final String[] HEADERS = { "Header1", "Header2", "Header3" };

--- a/src/test/java/net/imagej/table/DefaultByteTableTest.java
+++ b/src/test/java/net/imagej/table/DefaultByteTableTest.java
@@ -42,7 +42,10 @@ import org.junit.Test;
  * Tests {@link DefaultByteTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated replaced by {@link org.scijava.table.DefaultByteTableTest}
  */
+@Deprecated
 public class DefaultByteTableTest {
 
 	private static final String[] HEADERS = { "Header1", "Header2" };

--- a/src/test/java/net/imagej/table/DefaultCharTableTest.java
+++ b/src/test/java/net/imagej/table/DefaultCharTableTest.java
@@ -42,7 +42,10 @@ import org.junit.Test;
  * Tests {@link DefaultCharTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated replaced by {@link org.scijava.table.DefaultCharTableTest}
  */
+@Deprecated
 public class DefaultCharTableTest {
 
 	private static final String[] HEADERS = { "Header1", "Header2", "Header3" };

--- a/src/test/java/net/imagej/table/DefaultFloatTableTest.java
+++ b/src/test/java/net/imagej/table/DefaultFloatTableTest.java
@@ -42,7 +42,10 @@ import org.junit.Test;
  * Tests {@link DefaultFloatTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated replaced by {@link org.scijava.table.DefaultFloatTableTest}
  */
+@Deprecated
 public class DefaultFloatTableTest {
 
 	private static final String[] HEADERS = { "Header1", "Header2", "Header3",

--- a/src/test/java/net/imagej/table/DefaultGenericTableTest.java
+++ b/src/test/java/net/imagej/table/DefaultGenericTableTest.java
@@ -43,7 +43,10 @@ import org.junit.Test;
  * Tests {@link DefaultGenericTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated replaced by {@link org.scijava.table.DefaultGenericTableTest}
  */
+@Deprecated
 public class DefaultGenericTableTest {
 
 	@Test

--- a/src/test/java/net/imagej/table/DefaultIntTableTest.java
+++ b/src/test/java/net/imagej/table/DefaultIntTableTest.java
@@ -42,7 +42,10 @@ import org.junit.Test;
  * Tests {@link DefaultIntTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated replaced by {@link org.scijava.table.DefaultIntTableTest}
  */
+@Deprecated
 public class DefaultIntTableTest {
 
 	private static final String[] HEADERS = { "Header1", "Header2", "Header3",

--- a/src/test/java/net/imagej/table/DefaultLongTableTest.java
+++ b/src/test/java/net/imagej/table/DefaultLongTableTest.java
@@ -42,7 +42,10 @@ import org.junit.Test;
  * Tests {@link DefaultLongTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated replaced by {@link org.scijava.table.DefaultLongTableTest}
  */
+@Deprecated
 public class DefaultLongTableTest {
 
 	private static final String[] HEADERS = { "Header1", "Header2" };

--- a/src/test/java/net/imagej/table/DefaultResultsTableTest.java
+++ b/src/test/java/net/imagej/table/DefaultResultsTableTest.java
@@ -38,6 +38,8 @@ import java.util.List;
 
 import org.junit.Test;
 
+import org.scijava.table.DoubleColumn;
+
 /**
  * Tests {@link DefaultResultsTable}.
  * 

--- a/src/test/java/net/imagej/table/DefaultShortTableTest.java
+++ b/src/test/java/net/imagej/table/DefaultShortTableTest.java
@@ -42,7 +42,10 @@ import org.junit.Test;
  * Tests {@link DefaultShortTable}.
  *
  * @author Alison Walter
+ * 
+ * @deprecated replaced by {@link org.scijava.table.DefaultShortTableTest}
  */
+@Deprecated
 public class DefaultShortTableTest {
 
 	private static final String[] HEADERS = { "Header1", "Header2", "Header3",


### PR DESCRIPTION
Note that `ResultsTable` and `DefaultResultsTable` as well as `TableService` and `DefaultTableService` have _not_ been deprecated. Instead, their API changed from `net.imagej.table.Table` to `org.scijava.table.Table`.
In addition, `DefaultTableDisplay` has been reduced to a stub, as functionality for displaying 1D and 2D `double` arrays is now in `org.scijava.table.DefaultTableDisplay`.

These changes require increasing the major version (or minor as we are pre-1.0.0).
