### PR TITLE
Prevent converters from being reset to Type bounds upon rebuild

### DIFF
--- a/src/main/java/net/imagej/display/DefaultDatasetView.java
+++ b/src/main/java/net/imagej/display/DefaultDatasetView.java
@@ -502,21 +502,23 @@ public class DefaultDatasetView extends AbstractDataView implements DatasetView
 
 	/** Uninitializes the view. */
 	private void uninitializeView() {
-		converters.clear();
 		projector = null;
 	}
 
 	/** Initializes the view. */
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private void initializeView(final boolean composite) {
-		converters.clear();
-		final int channelCount = getChannelCount();
-		for (int c = 0; c < channelCount; c++) {
-			autoscale(c);
-			final RealLUTConverter converter =
-				new RealLUTConverter(getData().getImgPlus().getChannelMinimum(c),
-					getData().getImgPlus().getChannelMaximum(c), null);
-			converters.add(converter);
+		// If there are no converters (e.g. after creation), autoscale them!
+		// If there are converters, don't overwrite them!
+		if (converters.isEmpty()) {
+			final int channelCount = getChannelCount();
+			for (int c = 0; c < channelCount; c++) {
+				autoscale(c);
+				final RealLUTConverter converter =
+					new RealLUTConverter(getData().getImgPlus().getChannelMinimum(c),
+						getData().getImgPlus().getChannelMaximum(c), null);
+				converters.add(converter);
+			}
 		}
 
 		final ImgPlus<?> img = getData().getImgPlus();


### PR DESCRIPTION
A bug within `rebuild()` caused any changes made to the channel ranges through [`setChannelRange()`](https://github.com/imagej/imagej-common/blob/50b5cc6a0290422cc999e3342a16f5c434d4e75e/src/main/java/net/imagej/display/DefaultDatasetView.java#L145) to be overridden upon the next call to `rebuild()`, which is problematic considering that `rebuild()` has to be called to update the `DefaultDatasetView` and see the changes that you want to make. This PR fixes this issue by only overriding the converters if there are none there in the first place (e.g. after the `DefaultDatasetView` was just created).

TODO:
* Create a test proving that the converters are not overridden after calling `rebuild()`.

Questions:
* Are there any other circumstances in which we would want to reset the converters? Since `autoscale` is a public method it could be called by the user, but was there a reason that I am not familiar with that this decision to always override was made?