### PR TITLE
Fix the behavior of DatasetFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.imagej</groupId>
 	<artifactId>imagej-common</artifactId>
-	<version>0.30.1-SNAPSHOT</version>
+	<version>0.31.0-SNAPSHOT</version>
 
 	<name>ImageJ Common</name>
 	<description>This library contains ImageJ's core image data model, based on ImgLib2. It is the primary mechanism by which image data is managed internally by ImageJ2. This component also provides the corresponding core image display logic for user interfaces.</description>

--- a/src/main/java/net/imagej/Dataset.java
+++ b/src/main/java/net/imagej/Dataset.java
@@ -237,5 +237,8 @@ public interface Dataset extends Data, ImgPlusMetadata, Img<RealType<?>> {
 	// -- Img methods --
 
 	@Override
+	Dataset copy();
+
+	@Override
 	DatasetFactory factory();
 }

--- a/src/main/java/net/imagej/DatasetFactory.java
+++ b/src/main/java/net/imagej/DatasetFactory.java
@@ -31,47 +31,94 @@
 
 package net.imagej;
 
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 import net.imglib2.Dimensions;
-import net.imglib2.exception.IncompatibleTypeException;
-import net.imglib2.img.ImgFactory;
+import net.imglib2.img.Img;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.util.Util;
 
 /**
- * Base class for {@link ImgFactory} classes which produce {@link Dataset}s.
+ * A factory which produces {@link Dataset}s.
+ * <p>
+ * This class extends the more type-safe {@link DatasetImgFactory} to eliminate
+ * the generic parameter.
+ * </p>
  *
  * @author Curtis Rueden
  */
-public abstract class DatasetFactory extends ImgFactory<RealType<?>> {
+public class DatasetFactory extends DatasetImgFactory<RealType<?>> {
 
-	public DatasetFactory(final RealType<?> type) {
-		super(type);
+	private Function<Img<?>, Dataset> wrapper;
+
+	public DatasetFactory(final RealType<?> type, final Dataset dataset,
+		final ImgCreator creator, final Function<Img<?>, Dataset> wrapper)
+	{
+		super(type, dataset, creator);
+		this.wrapper = wrapper;
 	}
 
 	@Override
-	public abstract Dataset create(final long... dimensions);
+	public Dataset create(final long... dimensions) {
+		return wrapper.apply(super.create(dimensions));
+	}
 
 	@Override
 	public Dataset create(final Dimensions dimensions) {
-		final long[] size = new long[dimensions.numDimensions()];
-		dimensions.dimensions(size);
-		return create(size);
+		// NB: super.create(Dimensions) calls create(long[]).
+		return (Dataset) super.create(dimensions);
 	}
 
 	@Override
 	public Dataset create(final int[] dimensions) {
-		return create(Util.int2long(dimensions));
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <S> ImgFactory<S> imgFactory(final S type)
-		throws IncompatibleTypeException
-	{
-		return (ImgFactory<S>) this;
+		// NB: super.create(int[]) calls create(long[]).
+		return (Dataset) super.create(dimensions);
 	}
 
 	@Deprecated
 	@Override
-	public abstract Dataset create(final long[] dim, final RealType<?> type);
+	public Dataset create(final long[] dim, final RealType<?> type) {
+		return wrapper.apply(super.create(dim, type));
+	}
+
+	@Deprecated
+	@Override
+	public Dataset create(final Dimensions dim, final RealType<?> type) {
+		// NB: super.create(Dimensions, RealType) calls create(long[], RealType).
+		return (Dataset) super.create(dim, type);
+	}
+
+	@Deprecated
+	@Override
+	public Dataset create(final int[] dim, final RealType<?> type) {
+		// NB: super.create(int[], RealType) calls create(long[], RealType).
+		return (Dataset) super.create(dim, type);
+	}
+
+	@Deprecated
+	@Override
+	public Dataset create(final Supplier<RealType<?>> typeSupplier,
+		final long... dim)
+	{
+		// NB: super.create(Supplier, long[]) calls create(long[], RealType).
+		return (Dataset) super.create(typeSupplier, dim);
+	}
+
+	@Deprecated
+	@Override
+	public Dataset create(final Supplier<RealType<?>> typeSupplier,
+		final Dimensions dim)
+	{
+		// NB: super.create(Supplier, Dimensions) calls create(Dimensions, RealType).
+		return (Dataset) super.create(typeSupplier, dim);
+	}
+
+	@Deprecated
+	@Override
+	public Dataset create(final Supplier<RealType<?>> typeSupplier,
+		final int[] dim)
+	{
+		// NB: super.create(Supplier, int[]) calls create(int[], RealType).
+		return (Dataset) super.create(typeSupplier, dim);
+	}
 }

--- a/src/main/java/net/imagej/DatasetImgFactory.java
+++ b/src/main/java/net/imagej/DatasetImgFactory.java
@@ -1,0 +1,91 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2020 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej;
+
+import net.imglib2.Dimensions;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.util.Util;
+
+/**
+ * Base class for {@link ImgFactory} objects of {@link Dataset} implementations.
+ *
+ * @author Curtis Rueden
+ */
+public class DatasetImgFactory<T> extends ImgFactory<T> {
+
+	private Dataset dataset;
+	private ImgCreator creator;
+
+	public DatasetImgFactory(final T type, final Dataset dataset,
+		final ImgCreator creator)
+	{
+		super(type);
+		this.dataset = dataset;
+		this.creator = creator;
+	}
+
+	@Override
+	public Img<T> create(final long... dimensions) {
+		return creator.create(dataset, dimensions, type());
+	}
+
+	@Override
+	public Img<T> create(final Dimensions dimensions) {
+		final long[] size = new long[dimensions.numDimensions()];
+		dimensions.dimensions(size);
+		return create(size);
+	}
+
+	@Override
+	public Img<T> create(final int[] dimensions) {
+		return create(Util.int2long(dimensions));
+	}
+
+	@Override
+	public <S> DatasetImgFactory<S> imgFactory(final S type)
+		throws IncompatibleTypeException
+	{
+		return new DatasetImgFactory<>(type, dataset, creator);
+	}
+
+	@Deprecated
+	@Override
+	public Img<T> create(final long[] dim, final T type) {
+		return creator.create(dataset, dim, type);
+	}
+
+	interface ImgCreator {
+		<T> Img<T> create(Dataset dataset, long[] dims, T type);
+	}
+}

--- a/src/main/java/net/imagej/DatasetService.java
+++ b/src/main/java/net/imagej/DatasetService.java
@@ -40,7 +40,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
-import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.object.ObjectService;

--- a/src/main/java/net/imagej/DefaultDataset.java
+++ b/src/main/java/net/imagej/DefaultDataset.java
@@ -713,7 +713,7 @@ public class DefaultDataset extends AbstractData implements Dataset {
 	}
 
 	@Override
-	public Img<RealType<?>> copy() {
+	public Dataset copy() {
 		final ImgPlus<? extends RealType<?>> copy = getImgPlus().copy();
 		return new DefaultDataset(getContext(), copy);
 	}

--- a/src/main/java/net/imagej/DefaultDataset.java
+++ b/src/main/java/net/imagej/DefaultDataset.java
@@ -692,6 +692,51 @@ public class DefaultDataset extends AbstractData implements Dataset {
 		return new ImgPlus<>(blankImg, img);
 	}
 
+	/**
+	 * Creates an {@link Img} of the given dimensions and type, using the
+	 * associated {@link ImgFactory} of the specified {@link Dataset}.
+	 */
+	private static <T> Img<T> createImg(final Dataset dataset,
+		final long[] dim, final T type)
+	{
+		final ImgFactory<T> factory;
+		try {
+			factory = dataset.getImgPlus().factory().imgFactory(type);
+		}
+		catch (final IncompatibleTypeException exc) {
+			throw new IllegalStateException("Ill-understood type weirdness", exc);
+		}
+		return factory.create(dim);
+	}
+
+	/**
+	 * Wraps the given {@link Img} as a {@link Dataset} using best available
+	 * means.
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private Dataset wrapAsDataset(final Img<?> img) {
+		final Context ctx = getContext();
+
+		// Img -> ImgPlus, with default metadata.
+		final ImgPlus<?> imp = img instanceof ImgPlus ? //
+			(ImgPlus<?>) img : new ImgPlus<>(img);
+
+		// Wrap ImgPlus to Dataset using DatasetService, if available.
+		final DatasetService datasetService = ctx.getService(DatasetService.class);
+		final Object type = imp.firstElement();
+		if (datasetService != null && type instanceof Type) {
+			return datasetService.create((ImgPlus) imp);
+		}
+
+		// Wrap ImgPlus using DefaultDataset constructor, if compatible.
+		if (type instanceof RealType) {
+			return new DefaultDataset(ctx, (ImgPlus) imp);
+		}
+
+		throw new IllegalArgumentException("Unsupported type: " + //
+			type.getClass().getName());
+	}
+
 	private <T extends RealType<?>> ImgPlus<T> wrapAsImgPlus(final Img<T> newImg,
 		final CalibratedAxis... calibAxes)
 	{
@@ -720,35 +765,8 @@ public class DefaultDataset extends AbstractData implements Dataset {
 
 	@Override
 	public DatasetFactory factory() {
-		return new DatasetFactory(getType()) {
-
-			@Override
-			public Dataset create(final long... dimensions) {
-				final ImgPlus<RealType<?>> imp = makeImgPlus(dimensions, type());
-				return new DefaultDataset(getContext(), imp);
-			}
-
-			@Deprecated
-			@Override
-			public Dataset create(final long[] dimensions, final RealType<?> type) {
-				final ImgPlus<RealType<?>> imp = makeImgPlus(dimensions, type);
-				return new DefaultDataset(getContext(), imp);
-			}
-
-			private <T> ImgPlus<T> makeImgPlus(final long[] dim, final T type) {
-				final ImgFactory<T> factory;
-				try {
-					factory = getImgPlus().factory().imgFactory(type);
-				}
-				catch (final IncompatibleTypeException exc) {
-					throw new IllegalStateException("Ill-understood type weirdness", exc);
-				}
-				@SuppressWarnings("deprecation")
-				final Img<T> img = factory.create(dim, type);
-				return img instanceof ImgPlus ?
-					(ImgPlus<T>) img : new ImgPlus<>(img, getImgPlus());
-			}
-		};
+		return new DatasetFactory(getType(), this, //
+			DefaultDataset::createImg, this::wrapAsDataset);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/net/imagej/DefaultDatasetService.java
+++ b/src/main/java/net/imagej/DefaultDatasetService.java
@@ -203,15 +203,14 @@ public final class DefaultDatasetService extends AbstractService implements
 	}
 
 	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public <T extends Type<T>> Dataset create(final ImgPlus<T> imgPlus) {
-		T type = imgPlus.firstElement();
-		if(type instanceof ARGBType)
-			return createARGBType((ImgPlus) imgPlus);
-		if(type instanceof RealType)
-			return createRealType((ImgPlus) imgPlus);
+		final T type = imgPlus.firstElement();
+		if (type instanceof ARGBType) return createARGBType((ImgPlus) imgPlus);
+		if (type instanceof RealType) return createRealType((ImgPlus) imgPlus);
 		throw new IllegalArgumentException(
-				"Only RealType and ARGBType are supported. Given pixel type: "
-						+ type.getClass().getSimpleName());
+			"Only RealType and ARGBType are supported. Given pixel type: " + //
+				type.getClass().getName());
 	}
 
 	private < T extends RealType< T > > Dataset createRealType(

--- a/src/test/java/net/imagej/AbstractDatasetTest.java
+++ b/src/test/java/net/imagej/AbstractDatasetTest.java
@@ -31,10 +31,6 @@
 
 package net.imagej;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-
-import net.imglib2.IterableInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.cell.CellImgFactory;
@@ -87,29 +83,5 @@ public class AbstractDatasetTest {
 
 	protected Dataset createNonplanarDataset() {
 		return createDataset(new CellImgFactory<>(new IntType()));
-	}
-
-	protected void assertImagesMatch(final IterableInterval<?> image1,
-		final IterableInterval<?> image2, final Class<?> type1,
-		final Class<?> type2)
-	{
-		assertEquals(image1.numDimensions(), image2.numDimensions());
-		for (int i = 0; i < image1.numDimensions(); i++) {
-			assertEquals(image1.dimension(i), image2.dimension(i));
-		}
-		assertSame(img(image1).getClass(), img(image2).getClass());
-		assertSame(type1, image1.firstElement().getClass());
-		assertSame(type2, image2.firstElement().getClass());
-	}
-
-	private Img<?> img(final IterableInterval<?> image) {
-		if (image instanceof Dataset) {
-			return ((Dataset) image).getImgPlus().getImg();
-		}
-		if (image instanceof Img) {
-			return (Img<?>) image;
-		}
-		throw new IllegalArgumentException(//
-			"No relevant Img for type: " + image.getClass().getName());
 	}
 }

--- a/src/test/java/net/imagej/AbstractDatasetTest.java
+++ b/src/test/java/net/imagej/AbstractDatasetTest.java
@@ -34,6 +34,7 @@ package net.imagej;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
+import net.imglib2.IterableInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.ImgFactory;
 import net.imglib2.img.cell.CellImgFactory;
@@ -88,16 +89,27 @@ public class AbstractDatasetTest {
 		return createDataset(new CellImgFactory<>(new IntType()));
 	}
 
-	protected void assertDatasetsMatch(final Dataset d, final Dataset d2,
-		final Class<?> dType, final Class<?> d2Type)
+	protected void assertImagesMatch(final IterableInterval<?> image1,
+		final IterableInterval<?> image2, final Class<?> type1,
+		final Class<?> type2)
 	{
-		assertEquals(d.numDimensions(), d2.numDimensions());
-		for (int i = 0; i < d.numDimensions(); i++) {
-			assertEquals(d.dimension(i), d2.dimension(i));
+		assertEquals(image1.numDimensions(), image2.numDimensions());
+		for (int i = 0; i < image1.numDimensions(); i++) {
+			assertEquals(image1.dimension(i), image2.dimension(i));
 		}
-		assertSame(d.getImgPlus().getImg().getClass(), //
-			d2.getImgPlus().getImg().getClass());
-		assertSame(dType, d.getType().getClass());
-		assertSame(d2Type, d2.getType().getClass());
+		assertSame(img(image1).getClass(), img(image2).getClass());
+		assertSame(type1, image1.firstElement().getClass());
+		assertSame(type2, image2.firstElement().getClass());
+	}
+
+	private Img<?> img(final IterableInterval<?> image) {
+		if (image instanceof Dataset) {
+			return ((Dataset) image).getImgPlus().getImg();
+		}
+		if (image instanceof Img) {
+			return (Img<?>) image;
+		}
+		throw new IllegalArgumentException(//
+			"No relevant Img for type: " + image.getClass().getName());
 	}
 }

--- a/src/test/java/net/imagej/AbstractDatasetTest.java
+++ b/src/test/java/net/imagej/AbstractDatasetTest.java
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2020 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.img.planar.PlanarImgFactory;
+import net.imglib2.type.numeric.integer.IntType;
+
+import org.junit.After;
+import org.junit.Before;
+import org.scijava.Context;
+
+/**
+ * Base class for {@link Dataset}-related tests.
+ *
+ * @author Barry DeZonia
+ * @author Richard Domander
+ * @author Curtis Rueden
+ */
+public class AbstractDatasetTest {
+
+	protected static final int CPLANES = 2;
+	protected static final int ZPLANES = 3;
+	protected static final int TPLANES = 4;
+	protected static final long[] DIMENSIONS = { 4, 4, CPLANES, ZPLANES, TPLANES };
+
+	protected Context context;
+	protected DatasetService datasetService;
+
+	@Before
+	public void setUp() {
+		context = new Context(DatasetService.class);
+		datasetService = context.service(DatasetService.class);
+	}
+
+	@After
+	public void tearDown() {
+		context.dispose();
+	}
+
+	// -- Internal methods --
+
+	protected Dataset createDataset(final ImgFactory<IntType> factory) {
+		final Img<IntType> img = factory.create(DIMENSIONS);
+		final ImgPlus<IntType> imgPlus = new ImgPlus<>(img);
+		return datasetService.create(imgPlus);
+	}
+
+	protected Dataset createPlanarDataset() {
+		return createDataset(new PlanarImgFactory<>(new IntType()));
+	}
+
+	protected Dataset createNonplanarDataset() {
+		return createDataset(new CellImgFactory<>(new IntType()));
+	}
+
+	protected void assertDatasetsMatch(final Dataset d, final Dataset d2,
+		final Class<?> dType, final Class<?> d2Type)
+	{
+		assertEquals(d.numDimensions(), d2.numDimensions());
+		for (int i = 0; i < d.numDimensions(); i++) {
+			assertEquals(d.dimension(i), d2.dimension(i));
+		}
+		assertSame(d.getImgPlus().getImg().getClass(), //
+			d2.getImgPlus().getImg().getClass());
+		assertSame(dType, d.getType().getClass());
+		assertSame(d2Type, d2.getType().getClass());
+	}
+}

--- a/src/test/java/net/imagej/DatasetFactoryTest.java
+++ b/src/test/java/net/imagej/DatasetFactoryTest.java
@@ -46,13 +46,13 @@ public class DatasetFactoryTest extends AbstractDatasetTest {
 	public void testPlanar() {
 		final Dataset planar = createPlanarDataset();
 		final Dataset planar2 = planar.factory().create(DIMENSIONS);
-		assertDatasetsMatch(planar, planar2, IntType.class, IntType.class);
+		assertImagesMatch(planar, planar2, IntType.class, IntType.class);
 	}
 
 	@Test
 	public void testCell() {
 		final Dataset cell = createNonplanarDataset();
 		final Dataset cell2 = cell.factory().create(DIMENSIONS);
-		assertDatasetsMatch(cell, cell2, IntType.class, IntType.class);
+		assertImagesMatch(cell, cell2, IntType.class, IntType.class);
 	}
 }

--- a/src/test/java/net/imagej/DatasetFactoryTest.java
+++ b/src/test/java/net/imagej/DatasetFactoryTest.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2020 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej;
+
+import net.imglib2.type.numeric.integer.IntType;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link DatasetFactory}.
+ *
+ * @author Curtis Rueden
+ */
+public class DatasetFactoryTest extends AbstractDatasetTest {
+
+	@Test
+	public void testPlanar() {
+		final Dataset planar = createPlanarDataset();
+		final Dataset planar2 = planar.factory().create(DIMENSIONS);
+		assertDatasetsMatch(planar, planar2, IntType.class, IntType.class);
+	}
+
+	@Test
+	public void testCell() {
+		final Dataset cell = createNonplanarDataset();
+		final Dataset cell2 = cell.factory().create(DIMENSIONS);
+		assertDatasetsMatch(cell, cell2, IntType.class, IntType.class);
+	}
+}

--- a/src/test/java/net/imagej/DatasetTest.java
+++ b/src/test/java/net/imagej/DatasetTest.java
@@ -43,17 +43,10 @@ import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
 import net.imagej.axis.CalibratedAxis;
 import net.imglib2.RandomAccess;
-import net.imglib2.img.Img;
-import net.imglib2.img.ImgFactory;
-import net.imglib2.img.cell.CellImgFactory;
-import net.imglib2.img.planar.PlanarImgFactory;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.IntType;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.scijava.Context;
 
 /**
  * Unit tests for {@link Dataset}.
@@ -62,31 +55,9 @@ import org.scijava.Context;
  * @author Richard Domander
  * @author Curtis Rueden
  */
-public class DatasetTest {
+public class DatasetTest extends AbstractDatasetTest {
 
 	// -- private interface --
-
-	private static final int CPLANES = 2;
-	private static final int ZPLANES = 3;
-	private static final int TPLANES = 4;
-	private static final long[] DIMENSIONS = { 4, 4, CPLANES, ZPLANES, TPLANES };
-
-	private Context context;
-	private DatasetService datasetService;
-
-	private Dataset createDataset(final ImgFactory<IntType> factory) {
-		final Img<IntType> img = factory.create(DIMENSIONS);
-		final ImgPlus<IntType> imgPlus = new ImgPlus<>(img);
-		return datasetService.create(imgPlus);
-	}
-
-	private Dataset createPlanarDataset() {
-		return createDataset(new PlanarImgFactory<>(new IntType()));
-	}
-
-	private Dataset createNonplanarDataset() {
-		return createDataset(new CellImgFactory<>(new IntType()));
-	}
 
 	private int planeValue(final int c, final int z, final int t) {
 		return 100 * t + 10 * z + 1 * c;
@@ -177,45 +148,10 @@ public class DatasetTest {
 
 	// -- public tests --
 
-	@Before
-	public void setUp() {
-		context = new Context(DatasetService.class);
-		datasetService = context.getService(DatasetService.class);
-	}
-
-	@After
-	public void tearDown() {
-		context.dispose();
-	}
-
 	@Test
 	public void testGetPlane() {
 		testPlanarCase();
 		testNonplanarCase();
-	}
-
-	@Test
-	public void testFactory() {
-		final Dataset planar = createPlanarDataset();
-		final Dataset planar2 = planar.factory().create(DIMENSIONS);
-		assertDatasetsMatch(planar, planar2);
-		assertSame(IntType.class, planar.getType().getClass());
-		assertSame(IntType.class, planar2.getType().getClass());
-
-		final Dataset cell = createNonplanarDataset();
-		final Dataset cell2 = cell.factory().create(DIMENSIONS);
-		assertDatasetsMatch(cell, cell2);
-		assertSame(IntType.class, cell.getType().getClass());
-		assertSame(IntType.class, cell2.getType().getClass());
-	}
-
-	private void assertDatasetsMatch(final Dataset d, final Dataset d2) {
-		assertEquals(d.numDimensions(), d2.numDimensions());
-		for (int i = 0; i < d.numDimensions(); i++) {
-			assertEquals(d.dimension(i), d2.dimension(i));
-		}
-		assertSame(d.getImgPlus().getImg().getClass(), //
-			d2.getImgPlus().getImg().getClass());
 	}
 
 	/**


### PR DESCRIPTION
This in turn fixes the behavior of several ops in imagej-ops including `create.img` and the `convert` ops, which in turn fixes the `Subtract_First_Image_Stack.py` and `Apply_Threshold.py` scripts in the imagej-scripting examples.