### PR TITLE
Add an axis with explicitly enumerated values

### DIFF
--- a/src/main/java/net/imagej/axis/EnumeratedAxis.java
+++ b/src/main/java/net/imagej/axis/EnumeratedAxis.java
@@ -136,14 +136,11 @@ public class EnumeratedAxis extends AbstractCalibratedAxis {
 	@Override
 	public double calibratedValue(final double rawValue) {
 		if (values.length == 1) return values[0]; // Constant-valued axis.
-		if (rawValue >= Integer.MAX_VALUE) {
-			throw new IllegalArgumentException("Raw value too large: " + rawValue);
-		}
-		final int i0 = (int) Math.floor(rawValue);
-		final int i1 = (int) Math.ceil(rawValue);
+		final double i0 = Math.floor(rawValue);
+		final double i1 = Math.ceil(rawValue);
 		if (i0 == i1 && i0 >= 0 && i0 < values.length) {
 			// Integer index with known calibrated value: return it directly.
-			return values[i0];
+			return values[(int) i0];
 		}
 		if (i0 < 0) {
 			// Extrapolate from first two values.
@@ -160,7 +157,7 @@ public class EnumeratedAxis extends AbstractCalibratedAxis {
 		}
 		// Interpolate between two nearest values.
 		final double w = rawValue - i0;
-		return (1 - w) * values[i0] + w * values[i1];
+		return (1 - w) * values[(int) i0] + w * values[(int) i1];
 	}
 
 	@Override

--- a/src/main/java/net/imagej/axis/EnumeratedAxis.java
+++ b/src/main/java/net/imagej/axis/EnumeratedAxis.java
@@ -1,0 +1,172 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2020 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.axis;
+
+import java.util.Arrays;
+
+/**
+ * A {@link CalibratedAxis} whose coordinate values are explicitly enumerated by
+ * a list. Out-of-bounds calibrated values are linearly extrapolated from the
+ * two nearest known coordinates. Non-integer calibrated values are linearly
+ * interpolated from the two nearest integer indices.
+ * 
+ * @author Curtis Rueden
+ */
+public class EnumeratedAxis extends AbstractCalibratedAxis {
+
+	private double[] values;
+
+	/**
+	 * Creates an axis whose calibrated values are defined by the given
+	 * {@code values} array.
+	 * 
+	 * @param type The type of axis (e.g. {@link Axes#X} or {@link Axes#TIME}.
+	 * @param values Array of calibrated values. The first element of the array is
+	 *          the calibrated value at raw position 0, the second element is the
+	 *          calibrated value at raw position 1, and so forth. Intermediate and
+	 *          out-of-bounds calibrated values are inferred by linear
+	 *          interpolation or extrapolation, respectively.
+	 */
+	public EnumeratedAxis(final AxisType type, final double[] values) {
+		super(type);
+		setValues(values);
+	}
+
+	/**
+	 * Creates an axis whose calibrated values are defined by the given
+	 * {@code values} array.
+	 * 
+	 * @param type The type of axis (e.g. {@link Axes#X} or {@link Axes#TIME}.
+	 * @param unit The unit of the axis (e.g. microns or seconds).
+	 * @param values Array of calibrated values. The first element of the array is
+	 *          the calibrated value at raw position 0, the second element is the
+	 *          calibrated value at raw position 1, and so forth. Intermediate and
+	 *          out-of-bounds calibrated values are inferred by linear
+	 *          interpolation or extrapolation, respectively.
+	 */
+	public EnumeratedAxis(final AxisType type, final String unit,
+		final double[] values)
+	{
+		super(type, unit);
+		setValues(values);
+	}
+
+	// -- EnumeratedAxis methods --
+
+	/**
+	 * Sets the axis's calibrated values. The array reference is used directly,
+	 * without copying.
+	 * 
+	 * @param values Array of calibrated values. The first element of the array is
+	 *          the calibrated value at raw position 0, the second element is the
+	 *          calibrated value at raw position 1, and so forth. Intermediate and
+	 *          out-of-bounds calibrated values are inferred by linear
+	 *          interpolation or extrapolation, respectively.
+	 */
+	public void setValues(final double[] values) {
+		if (values == null || values.length < 1) {
+			throw new IllegalArgumentException("Need at least one value");
+		}
+		this.values = values;
+	}
+
+	// -- Object methods --
+
+	@Override
+	public int hashCode() {
+		return super.hashCode() ^ Arrays.hashCode(values);
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (!(o instanceof EnumeratedAxis)) return false;
+		if (!super.equals(o)) return false;
+		final EnumeratedAxis other = (EnumeratedAxis) o;
+		return Arrays.equals(values, other.values);
+	}
+
+	// -- CalibratedAxis methods --
+
+	@Override
+	public double calibratedValue(final double rawValue) {
+		if (values.length == 1) return values[0]; // Constant-valued axis.
+		if (rawValue >= Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("Raw value too large: " + rawValue);
+		}
+		final int i0 = (int) Math.floor(rawValue);
+		final int i1 = (int) Math.ceil(rawValue);
+		if (i0 == i1 && i0 >= 0 && i0 < values.length) {
+			// Integer index with known calibrated value: return it directly.
+			return values[i0];
+		}
+		if (i0 < 0) {
+			// Extrapolate from first two values.
+			final double slope = values[1] - values[0];
+			final double offset = values[0];
+			return slope * rawValue + offset;
+		}
+		if (i1 >= values.length) {
+			// Extrapolate from last two values.
+			final int len = values.length;
+			final double slope = values[len - 1] - values[len - 2];
+			final double offset = values[len - 1];
+			return slope * (rawValue - len + 1) + offset;
+		}
+		// Interpolate between two nearest values.
+		final double w = rawValue - i0;
+		return (1 - w) * values[i0] + w * values[i1];
+	}
+
+	@Override
+	public double rawValue(final double calibratedValue) {
+		// NB: Assumes values array is sorted! We should document and/or enforce this.
+		final int index = Arrays.binarySearch(values, calibratedValue);
+		// TODO finish edge cases here.
+//		return index;
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public String generalEquation() {
+		return "N/A";
+	}
+
+	@Override
+	public String particularEquation() {
+		return "N/A";
+	}
+
+	@Override
+	public EnumeratedAxis copy() {
+		return new EnumeratedAxis(type(), unit(), values.clone());
+	}
+}

--- a/src/main/java/net/imagej/axis/EnumeratedAxis.java
+++ b/src/main/java/net/imagej/axis/EnumeratedAxis.java
@@ -58,14 +58,8 @@ public class EnumeratedAxis extends AbstractCalibratedAxis {
 	 *          out-of-bounds calibrated values are inferred by linear
 	 *          interpolation or extrapolation, respectively.
 	 */
-	public EnumeratedAxis(final AxisType type, final List<Double> values) {
-		super(type);
-
-		double[] values_arr = new double[values.size()];
-		for (int idx = 0; idx < values.size(); idx++) {
-			values_arr[idx] = values.get(idx);
-		}
-		setValues(values_arr);
+	public EnumeratedAxis(final AxisType type, final List<? extends Number> values) {
+		this(type, values.stream().mapToDouble(x -> x.doubleValue()).toArray());
 	}
 
 	/**

--- a/src/main/java/net/imagej/axis/EnumeratedAxis.java
+++ b/src/main/java/net/imagej/axis/EnumeratedAxis.java
@@ -32,6 +32,7 @@
 package net.imagej.axis;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * A {@link CalibratedAxis} whose coordinate values are explicitly enumerated by
@@ -44,6 +45,28 @@ import java.util.Arrays;
 public class EnumeratedAxis extends AbstractCalibratedAxis {
 
 	private double[] values;
+
+	/**
+	 * Creates an axis whose calibrated values are defined by the given list of
+	 * {@code values}. This is a convenience constructor which copies the list
+	 * values to a new array internally.
+	 * 
+	 * @param type The type of axis (e.g. {@link Axes#X} or {@link Axes#TIME}.
+	 * @param values List of calibrated values. The first element of the list is
+	 *          the calibrated value at raw position 0, the second element is the
+	 *          calibrated value at raw position 1, and so forth. Intermediate and
+	 *          out-of-bounds calibrated values are inferred by linear
+	 *          interpolation or extrapolation, respectively.
+	 */
+	public EnumeratedAxis(final AxisType type, final List<Double> values) {
+		super(type);
+
+		double[] values_arr = new double[values.size()];
+		for (int idx = 0; idx < values.size(); idx++) {
+			values_arr[idx] = values.get(idx);
+		}
+		setValues(values_arr);
+	}
 
 	/**
 	 * Creates an axis whose calibrated values are defined by the given

--- a/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
+++ b/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
@@ -108,6 +108,20 @@ public class EnumeratedAxisTest extends AbstractAxisTest {
 	}
 
 	@Test
+	public void testWayOutOfBounds() {
+		final double[] values = {10, 10.001, 10.999, 11};
+		final EnumeratedAxis axis = new EnumeratedAxis(Axes.get("pancakes"), values);
+		final double bigValue = 50000;
+		final double bigIndex = 1000 * (bigValue - 11) + 3;
+		final double smallValue = -50000;
+		final double smallIndex = -1000 * (10 - smallValue);
+		assertEquals(bigValue, axis.calibratedValue(bigIndex), 1e-7);
+		assertEquals(bigIndex, axis.rawValue(bigValue), 1e-4);
+		assertEquals(smallValue, axis.calibratedValue(smallIndex), 1e-7);
+		assertEquals(smallIndex, axis.rawValue(smallValue), 1e-4);
+	}
+
+	@Test
 	public void testCopy() {
 		final double[] values = {2, 3, 5, 7, 11, 13, 17};
 		final EnumeratedAxis axis = new EnumeratedAxis(Axes.get("primes"), values);

--- a/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
+++ b/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
@@ -34,6 +34,9 @@ package net.imagej.axis;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 
 /**
@@ -42,6 +45,19 @@ import org.junit.Test;
  * @author Curtis Rueden
  */
 public class EnumeratedAxisTest extends AbstractAxisTest {
+
+	@Test
+	public void testConstructors() {
+		final double[] array = {1, 2, 3, 5, 8, 13, 22};
+		final EnumeratedAxis axis1 = new EnumeratedAxis(Axes.get("fib"), array);
+		assertEquals(5, axis1.calibratedValue(3), 0.0);
+		assertEquals(13, axis1.calibratedValue(5), 0.0);
+
+		final List<Integer> list = Arrays.asList(2, 4, 8, 16, 32, 64, 128);
+		final EnumeratedAxis axis2 = new EnumeratedAxis(Axes.get("pow"), list);
+		assertEquals(16, axis2.calibratedValue(3), 0.0);
+		assertEquals(64, axis2.calibratedValue(5), 0.0);
+	}
 
 	@Test
 	public void testCalibratedValue() {

--- a/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
+++ b/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2020 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.axis;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link EnumeratedAxis}.
+ * 
+ * @author Curtis Rueden
+ */
+public class EnumeratedAxisTest extends AbstractAxisTest {
+
+	@Test
+	public void testCalibratedValue() {
+		final double[] values = {2, 3, 5, 7, 11, 13, 17};
+		final EnumeratedAxis axis = new EnumeratedAxis(Axes.get("primes"), values);
+		// Verify integer coordinates.
+		for (int i = 0; i < values.length; i++) {
+			assertEquals(values[i], axis.calibratedValue(i), 0.0);
+		}
+		// Verify interpolated coordinates.
+		assertEquals(3, axis.calibratedValue(1), 0.0);
+		assertEquals(4, axis.calibratedValue(1.5), 0.0);
+		assertEquals(5, axis.calibratedValue(2), 0.0);
+		assertEquals(10.5, axis.calibratedValue(3.875), 0.0);
+		// Verify extrapolated coordinates.
+		assertEquals(1, axis.calibratedValue(-1), 0.0);
+		assertEquals(0.5, axis.calibratedValue(-1.5), 0.0);
+		assertEquals(0.25, axis.calibratedValue(-1.75), 0.0);
+		assertEquals(0, axis.calibratedValue(-2), 0.0);
+		assertEquals(-98, axis.calibratedValue(-100), 0.0);
+		assertEquals(21, axis.calibratedValue(7), 0.0);
+		assertEquals(23, axis.calibratedValue(7.5), 0.0);
+		assertEquals(24.2, axis.calibratedValue(7.8), 0.0);
+		assertEquals(25, axis.calibratedValue(8), 0.0);
+		assertEquals(393, axis.calibratedValue(100), 0.0);
+	}
+
+//	@Test
+//	public void testRawValue() {
+//		// TODO
+//	}
+//
+	@Test
+	public void testCopy() {
+		final double[] values = {2, 3, 5, 7, 11, 13, 17};
+		final EnumeratedAxis axis = new EnumeratedAxis(Axes.get("primes"), values);
+		final EnumeratedAxis copy = axis.copy();
+		assertNotSame(axis, copy);
+		assertEquals(axis, copy);
+		for (int i = 0; i < values.length; i++) {
+			assertEquals(values[i], copy.calibratedValue(i), 0.0);
+		}
+		assertEquals(axis.hashCode(), copy.hashCode());
+	}
+}

--- a/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
+++ b/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
@@ -33,6 +33,7 @@ package net.imagej.axis;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
@@ -119,6 +120,15 @@ public class EnumeratedAxisTest extends AbstractAxisTest {
 		assertEquals(bigIndex, axis.rawValue(bigValue), 1e-4);
 		assertEquals(smallValue, axis.calibratedValue(smallIndex), 1e-7);
 		assertEquals(smallIndex, axis.rawValue(smallValue), 1e-4);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testNonInvertible() {
+		final double[] values = {3, 1, 4, 1, 5, 9, 2, 6};
+		final EnumeratedAxis axis = new EnumeratedAxis(Axes.get("pi"), values);
+		assertEquals(8, axis.calibratedValue(4.75), 0.0);
+		final double index = axis.rawValue(8);
+		fail("Unexpectedly successful inverse: " + index);
 	}
 
 	@Test

--- a/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
+++ b/src/test/java/net/imagej/axis/EnumeratedAxisTest.java
@@ -68,9 +68,7 @@ public class EnumeratedAxisTest extends AbstractAxisTest {
 			assertEquals(values[i], axis.calibratedValue(i), 0.0);
 		}
 		// Verify interpolated coordinates.
-		assertEquals(3, axis.calibratedValue(1), 0.0);
 		assertEquals(4, axis.calibratedValue(1.5), 0.0);
-		assertEquals(5, axis.calibratedValue(2), 0.0);
 		assertEquals(10.5, axis.calibratedValue(3.875), 0.0);
 		// Verify extrapolated coordinates.
 		assertEquals(1, axis.calibratedValue(-1), 0.0);
@@ -85,11 +83,30 @@ public class EnumeratedAxisTest extends AbstractAxisTest {
 		assertEquals(393, axis.calibratedValue(100), 0.0);
 	}
 
-//	@Test
-//	public void testRawValue() {
-//		// TODO
-//	}
-//
+	@Test
+	public void testRawValue() {
+		final double[] values = {2, 3, 5, 7, 11, 13, 17};
+		final EnumeratedAxis axis = new EnumeratedAxis(Axes.get("primes"), values);
+		// Verify integer coordinates.
+		for (int i = 0; i < values.length; i++) {
+			assertEquals(i, axis.rawValue(values[i]), 0.0);
+		}
+		// Verify interpolated coordinates.
+		assertEquals(1.5, axis.rawValue(4), 0.0);
+		assertEquals(3.875, axis.rawValue(10.5), 0.0);
+		// Verify extrapolated coordinates.
+		assertEquals(-1, axis.rawValue(1), 0.0);
+		assertEquals(-1.5, axis.rawValue(0.5), 0.0);
+		assertEquals(-1.75, axis.rawValue(0.25), 0.0);
+		assertEquals(-2, axis.rawValue(0), 0.0);
+		assertEquals(-100, axis.rawValue(-98), 0.0);
+		assertEquals(7, axis.rawValue(21), 0.0);
+		assertEquals(7.5, axis.rawValue(23), 0.0);
+		assertEquals(7.8, axis.rawValue(24.2), 1e-15); // NB: Binary rounding error.
+		assertEquals(8, axis.rawValue(25), 0.0);
+		assertEquals(100, axis.rawValue(393), 0.0);
+	}
+
 	@Test
 	public void testCopy() {
 		final double[] values = {2, 3, 5, 7, 11, 13, 17};


### PR DESCRIPTION
This implementation is analogous to the way [xarray](http://xarray.pydata.org/) handles axis calibration, and is intended for use converting between xarray and ImageJ image objects.