### PR TITLE
Add converters for ImgLabeling <-> Img

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>27.0.1</version>
+		<version>28.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -149,8 +149,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
-		<scijava-common.version>2.81.0</scijava-common.version>
-		<imglib2.version>5.8.0</imglib2.version>
+		<imglib2-roi.version>0.10.2</imglib2-roi.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/imagej/convert/ImgLabelingToImgConverter.java
+++ b/src/main/java/net/imagej/convert/ImgLabelingToImgConverter.java
@@ -1,0 +1,85 @@
+package net.imagej.convert;
+
+import java.util.Set;
+
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.Converter;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.util.Types;
+
+import net.imglib2.img.Img;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.roi.labeling.ImgLabeling;
+import net.imglib2.roi.labeling.LabelingMapping;
+import net.imglib2.type.numeric.IntegerType;
+
+/**
+ * This {@code Converter} converts an {@code ImgLabeling} to an {@code Img}.
+ * 
+ * If the {@code ImgLabeling} has non-overlapping integer labels, the result
+ * {@code Img} will be filled with values corresponding to those labels.
+ * Otherwise, {@code ImgLabeling#getIndexImg()} is returned.
+ * 
+ * @author Jan Eglinger
+ *
+ * @param <T>
+ *            the ImgLib2 type used for the index image of the labeling
+ */
+@SuppressWarnings("rawtypes")
+@Plugin(type = Converter.class)
+public class ImgLabelingToImgConverter<T extends IntegerType<T>> extends AbstractConverter<ImgLabeling, Img>{
+
+	@Parameter
+	private LogService log;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <I> I convert(Object object, Class<I> type) {
+		ImgLabeling<Integer, T> labeling = (ImgLabeling<Integer, T>) object;
+		// check if only singleton labels
+		if (!singletonLabels(labeling)) {
+			log.warn("Converting ImgLabeling with overlapping labels. Labels cannot be preserved in output, creating continuous integers.");
+			return (I) ((ImgLabeling) labeling).getIndexImg();
+		}
+		// check if labeling type is integer
+		if (!integerLabels(labeling)) {
+			log.warn("Converting non-integer label type. Labels cannot be preserved in output, creating continuous integers.");
+			return (I) (labeling).getIndexImg();
+		}
+		// else, create new img, populate with actual labels
+		Img<T> indexImg = (Img<T>) labeling.getIndexImg();
+		Img<T> img = indexImg.factory().create(indexImg);
+		LabelingMapping<Integer> mapping = labeling.getMapping();
+		LoopBuilder.setImages(labeling, img).forEachPixel( (l, i) -> {
+			Set<Integer> labels = mapping.labelsAtIndex(l.getIndex().getInteger());
+			if (!labels.isEmpty()) {
+				i.setInteger(labels.iterator().next()); // assuming singleton set here
+			}
+		});
+		return (I) img;
+	}
+
+	private boolean integerLabels(ImgLabeling labeling) {
+		// Check if the first non-empty label set is an integer
+		return Types.isAssignable(labeling.getMapping().labelsAtIndex(1).iterator().next().getClass(), Integer.class);
+	}
+
+	private boolean singletonLabels(ImgLabeling labeling) {
+		LabelingMapping mapping = labeling.getMapping();
+		// TODO should we actually iterate over sets to assert that each is a singleton?
+		return mapping.getLabels().size() == mapping.getLabelSets().size() - 1; // the empty set is always present
+	}
+
+	@Override
+	public Class<ImgLabeling> getInputType() {
+		return ImgLabeling.class;
+	}
+
+	@Override
+	public Class<Img> getOutputType() {
+		return Img.class;
+	}
+
+}

--- a/src/main/java/net/imagej/convert/ImgToImgLabelingConverter.java
+++ b/src/main/java/net/imagej/convert/ImgToImgLabelingConverter.java
@@ -1,0 +1,64 @@
+package net.imagej.convert;
+
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Plugin;
+
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.roi.labeling.ImgLabeling;
+import net.imglib2.roi.labeling.LabelingType;
+import net.imglib2.type.numeric.IntegerType;
+
+/**
+ * This {@code Converter} converts an {@code Img} to an {@code ImgLabeling}. The
+ * pixel values will be the labels of the result {@code ImgLabeling}.
+ * 
+ * @author Jan Eglinger
+ *
+ * @param <T>
+ *            the ImgLib2 type of the input {@code Img} and the index image of
+ *            the resulting {@code ImgLabeling}
+ */
+@SuppressWarnings("rawtypes")
+@Plugin(type = Converter.class)
+public class ImgToImgLabelingConverter<T extends IntegerType<T>> extends AbstractConverter<Img, ImgLabeling> {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <L> L convert(Object img, Class<L> type) {
+		Img<T> indexImg = ((Img<T>) img).factory().create(((Img<T>) img));
+		ImgLabeling<Integer, T> labeling = new ImgLabeling<>(indexImg);
+
+		LoopBuilder.setImages(((Img<T>) img), labeling).forEachPixel((i, l) -> {
+			int v = i.getInteger();
+			if (v != 0)
+				l.add(v);
+		});
+
+//		Cursor<T> imgCursor = ((Img<T>) img).cursor();
+//		Cursor<LabelingType<Integer>> labelCursor = labeling.cursor();
+//		while (imgCursor.hasNext()) {
+//			T value = imgCursor.next();
+//			if (value.getInteger() == 0) {
+//				labelCursor.fwd();
+//			} else {
+//				labelCursor.next().add(value.getInteger());
+//			}
+//		}
+
+		return (L) labeling;
+	}
+
+	@Override
+	public Class<Img> getInputType() {
+		return Img.class;
+	}
+
+	@Override
+	public Class<ImgLabeling> getOutputType() {
+		return ImgLabeling.class;
+	}
+
+}


### PR DESCRIPTION
* `Img -> ImgLabeling`:
  The labels of the result `ImgLabeling` will correspond to the pixel value of the input `Img`.
* `ImgLabeling -> Img`:
  If the input `ImgLabeling` has non-overlapping integer labels, the result `Img` will be filled with values corresponding to those labels.
  Otherwise, `ImgLabeling#getIndexImg()` is returned.

This behavior ensures that we can convert `Img -> ImgLabeling -> Img` without losing the label identity.

(the test uses `ImgLabeling.fromImageAndLabels` and requires `imglib2-roi` version `0.10.2`)