### PR TITLE
ImgLabeling converter: relax input from Img to RAI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
+		<imglib2.version>5.9.2</imglib2.version>
 		<imglib2-roi.version>0.10.2</imglib2-roi.version>
 	</properties>
 

--- a/src/main/java/net/imagej/convert/RandomAccessibleIntervalToImgLabelingConverter.java
+++ b/src/main/java/net/imagej/convert/RandomAccessibleIntervalToImgLabelingConverter.java
@@ -32,11 +32,11 @@ import org.scijava.convert.AbstractConverter;
 import org.scijava.convert.Converter;
 import org.scijava.plugin.Plugin;
 
-import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
+import net.imglib2.img.ImgView;
 import net.imglib2.loops.LoopBuilder;
 import net.imglib2.roi.labeling.ImgLabeling;
-import net.imglib2.roi.labeling.LabelingType;
 import net.imglib2.type.numeric.IntegerType;
 
 /**
@@ -51,37 +51,26 @@ import net.imglib2.type.numeric.IntegerType;
  */
 @SuppressWarnings("rawtypes")
 @Plugin(type = Converter.class)
-public class ImgToImgLabelingConverter<T extends IntegerType<T>> extends AbstractConverter<Img, ImgLabeling> {
+public class RandomAccessibleIntervalToImgLabelingConverter<T extends IntegerType<T>> extends AbstractConverter<RandomAccessibleInterval, ImgLabeling> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <L> L convert(Object img, Class<L> type) {
-		Img<T> indexImg = ((Img<T>) img).factory().create(((Img<T>) img));
+	public <L> L convert(Object rai, Class<L> type) {
+		Img<T> indexImg = ImgView.wrap((RandomAccessibleInterval<T>) rai).factory().create((RandomAccessibleInterval<T>) rai);
 		ImgLabeling<Integer, T> labeling = new ImgLabeling<>(indexImg);
 
-		LoopBuilder.setImages(((Img<T>) img), labeling).forEachPixel((i, l) -> {
+		LoopBuilder.setImages((RandomAccessibleInterval<T>) rai, labeling).forEachPixel((i, l) -> {
 			int v = i.getInteger();
 			if (v != 0)
 				l.add(v);
 		});
 
-//		Cursor<T> imgCursor = ((Img<T>) img).cursor();
-//		Cursor<LabelingType<Integer>> labelCursor = labeling.cursor();
-//		while (imgCursor.hasNext()) {
-//			T value = imgCursor.next();
-//			if (value.getInteger() == 0) {
-//				labelCursor.fwd();
-//			} else {
-//				labelCursor.next().add(value.getInteger());
-//			}
-//		}
-
 		return (L) labeling;
 	}
 
 	@Override
-	public Class<Img> getInputType() {
-		return Img.class;
+	public Class<RandomAccessibleInterval> getInputType() {
+		return RandomAccessibleInterval.class;
 	}
 
 	@Override

--- a/src/test/java/net/imagej/convert/ImgLabelingConversionTest.java
+++ b/src/test/java/net/imagej/convert/ImgLabelingConversionTest.java
@@ -28,9 +28,9 @@
  */
 package net.imagej.convert;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -45,6 +45,8 @@ import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
 
 public class ImgLabelingConversionTest {
 
@@ -66,7 +68,7 @@ public class ImgLabelingConversionTest {
 	public void testImgToImgLabelingConversion() {
 		Img<UnsignedByteType> img = createTestImg();
 		assertTrue(convertService.supports(img, ImgLabeling.class));
-		assertEquals(ImgToImgLabelingConverter.class, convertService.getHandler(img, ImgLabeling.class).getClass());
+		assertEquals(RandomAccessibleIntervalToImgLabelingConverter.class, convertService.getHandler(img, ImgLabeling.class).getClass());
 
 		ImgLabeling<?, ?> labeling = convertService.convert(img, ImgLabeling.class);
 		assertEquals(3, labeling.getMapping().numSets());
@@ -89,6 +91,17 @@ public class ImgLabelingConversionTest {
 		ImgLabeling<?, ?> labeling = convertService.convert(img, ImgLabeling.class);
 		Img<?> converted = convertService.convert(labeling, Img.class);
 		assertEquals(img.firstElement().getInteger(), ((IntegerType<?>)converted.firstElement()).getInteger());
+	}
+
+	@Test
+	public void testIntervalViewToImgLabelingConversion() {
+		Img<UnsignedByteType> img = createTestImg();
+		IntervalView<UnsignedByteType> slice = Views.hyperSlice(img, 0, 1);
+		assertTrue(convertService.supports(slice, ImgLabeling.class));
+		assertEquals(RandomAccessibleIntervalToImgLabelingConverter.class, convertService.getHandler(slice, ImgLabeling.class).getClass());
+
+		ImgLabeling<?, ?> labeling = convertService.convert(slice, ImgLabeling.class);
+		assertEquals(3, labeling.getMapping().numSets());
 	}
 
 	private ImgLabeling<Integer, UnsignedByteType> createTestImgLabeling() {


### PR DESCRIPTION
Replaces: `Img -> ImgLabeling`
by: `RandomAccessibleInterval -> ImgLabeling`

We want this converter to handle any `RandomAccessibleInterval`, since otherwise a conversion request from `RandomAccessibleInterval` to `ImgLabeling` could be picked up by `org.scijava.convert.DefaultConverter`, resulting in an undesired (and possibly invalid) `ImgLabeling` created by its default constructor.

This is a follow-up pull request to #93.

See also [this discussion](https://forum.image.sc/t/imglabeling-contains-no-labels-when-converted-from-slice-view/37216?u=imagejan) on the forum.