### PR TITLE
Adapt to changes in imglib2-5.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>28.0.0</version>
+		<version>29.2.1</version>
 		<relativePath />
 	</parent>
 
@@ -146,8 +146,6 @@
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
-
-		<imglib2-roi.version>0.10.2</imglib2-roi.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/imagej/types/BigComplex.java
+++ b/src/main/java/net/imagej/types/BigComplex.java
@@ -468,6 +468,16 @@ public class BigComplex implements ComplexType<BigComplex> {
 		mul(new BigComplex(BigDecimal.valueOf(c), BigDecimal.ZERO));
 	}
 
+	@Override
+	public void pow(BigComplex t) {
+		throw new UnsupportedOperationException("pow is not yet supported for BigComplex");
+	}
+
+	@Override
+	public void pow(double power) {
+		throw new UnsupportedOperationException("pow is not yet supported for BigComplex");
+	}
+
 	/**
 	 * Does complex conjugation on self.
 	 */

--- a/src/main/java/net/imagej/types/PreciseFixedComplexFloatType.java
+++ b/src/main/java/net/imagej/types/PreciseFixedComplexFloatType.java
@@ -195,6 +195,16 @@ public class PreciseFixedComplexFloatType implements
 	}
 
 	@Override
+	public void pow(PreciseFixedComplexFloatType t) {
+		throw new UnsupportedOperationException("pow is not yet supported for PreciseFixedComplexFloatType");
+	}
+
+	@Override
+	public void pow(double power) {
+		throw new UnsupportedOperationException("pow is not yet supported for PreciseFixedComplexFloatType");
+	}
+
+	@Override
 	public void setZero() {
 		real.setZero();
 		imag.setZero();

--- a/src/main/java/net/imagej/types/PreciseFixedFloatType.java
+++ b/src/main/java/net/imagej/types/PreciseFixedFloatType.java
@@ -244,6 +244,16 @@ public class PreciseFixedFloatType implements RealType<PreciseFixedFloatType> {
 	}
 
 	@Override
+	public void pow(PreciseFixedFloatType t) {
+		throw new UnsupportedOperationException("pow is not yet supported for PreciseFixedFloatType");
+	}
+
+	@Override
+	public void pow(double power) {
+		throw new UnsupportedOperationException("pow is not yet supported for PreciseFixedFloatType");
+	}
+
+	@Override
 	public void setZero() {
 		amount = BigInteger.ZERO;
 	}

--- a/src/main/java/net/imagej/types/UnboundedIntegerType.java
+++ b/src/main/java/net/imagej/types/UnboundedIntegerType.java
@@ -143,6 +143,16 @@ public class UnboundedIntegerType implements IntegerType<UnboundedIntegerType> {
 		doMul(val);
 	}
 
+	@Override
+	public void pow(UnboundedIntegerType t) {
+		throw new UnsupportedOperationException("pow is not yet supported for UnboundedIntegerType");
+	}
+
+	@Override
+	public void pow(double power) {
+		throw new UnsupportedOperationException("pow is not yet supported for UnboundedIntegerType");
+	}
+
 	// -- helpers --
 
 	private void doMul(BigDecimal factor) {


### PR DESCRIPTION
The `ComplexType` interface gained new API, we throw `UnsupportedOperationException` until someone has time to implement and test.