### PR TITLE
ROIService: allow converting ROIs to ImgLabeling

### DIFF
--- a/src/main/java/net/imagej/roi/ROIService.java
+++ b/src/main/java/net/imagej/roi/ROIService.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import net.imagej.Dataset;
 import net.imagej.ImageJService;
+import net.imglib2.Interval;
 import net.imglib2.KDTree;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
@@ -60,6 +61,7 @@ import net.imglib2.roi.geom.real.WritablePolyline;
 import net.imglib2.roi.geom.real.WritableRealPointCollection;
 import net.imglib2.roi.geom.real.WritableSphere;
 import net.imglib2.roi.geom.real.WritableSuperEllipsoid;
+import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.type.logic.BoolType;
 
 import org.scijava.service.Service;
@@ -582,4 +584,16 @@ public interface ROIService extends ImageJService {
 		return GeomMasks.openSuperEllipsoid(center, semiAxisLengths,
 			exponent);
 	}
+
+	/**
+	 * Get the ROIs of a {@link Dataset} as {@link ImgLabeling}
+	 */
+	default ImgLabeling<?, ?> toImgLabeling(Dataset dataset) {
+		return toImgLabeling(getROIs(dataset), dataset);
+	}
+
+	/**
+	 * Convert the ROIs in a
+	 */
+	ImgLabeling<?, ?> toImgLabeling(ROITree roiTree, Interval interval);
 }


### PR DESCRIPTION
This pull request adds two new signatures to `ROIService`:
* `toImgLabeling(ROITree roiTree, Interval interval)`, creating an `ImgLabeling` with the size of `interval` and an `Integer` label for all of the children of `roiTree`.
* `toImgLabeling(Dataset dataset)` creating an `ImgLabeling` taking the ROIs attached to `dataset`.

This makes it possible to write a script like this to get an `ImgLabeling` from the current overlay in Fiji:

```groovy
#@ ROIService roiService
#@ Dataset dataset

labeling = roiService.toImgLabeling(dataset)
result = labeling.getIndexImg() // to get something that can be displayed
```

<s>Also bump to `pom-scijava-29.2.1` (this requires pinning to `imglib2-5.9.2` as long as #95 is not merged).</s>
