### PR TITLE
DefaultUnitService: Fix Unicode replacement of µ character

### DIFF
--- a/src/main/java/net/imagej/units/DefaultUnitService.java
+++ b/src/main/java/net/imagej/units/DefaultUnitService.java
@@ -152,7 +152,7 @@ public class DefaultUnitService extends AbstractService implements UnitService {
 	 */
 	private String sanitizeUnitString(final String unitName) {
 		// Convert the mu symbol into "u".
-		return unitName.replace("\\u00B5", "u");
+		return unitName.replace("\\u00B5", "u").replace("\\u00b5", "u");
 	}
 
 	private Unit parseUnit(final String unitName) {

--- a/src/main/java/net/imagej/units/DefaultUnitService.java
+++ b/src/main/java/net/imagej/units/DefaultUnitService.java
@@ -54,6 +54,9 @@ import ucar.units.UnknownUnit;
  * Service for defining units and making unit conversions.
  *
  * @author Barry DeZonia
+ * @author Curtis Rueden
+ * @author Kyle Harrington
+ * @author Ulrik Günther
  */
 @Plugin(type = Service.class)
 public class DefaultUnitService extends AbstractService implements UnitService {

--- a/src/test/java/net/imagej/units/DefaultUnitServiceTest.java
+++ b/src/test/java/net/imagej/units/DefaultUnitServiceTest.java
@@ -87,5 +87,8 @@ public class DefaultUnitServiceTest {
 		final DefaultUnitService c = new DefaultUnitService();
 		assertEquals(0.1, c.value(100_000, "\\u00B5m", "meter"), 1e-16);
 		assertEquals(1_000_000.0, c.value(1, "meter", "\\u00B5m"), 0.0);
+
+		assertEquals(0.1, c.value(100_000, "\\u00b5m", "meter"), 1e-16);
+		assertEquals(1_000_000.0, c.value(1, "meter", "\\u00b5m"), 0.0);
 	}
 }

--- a/src/test/java/net/imagej/units/DefaultUnitServiceTest.java
+++ b/src/test/java/net/imagej/units/DefaultUnitServiceTest.java
@@ -37,6 +37,9 @@ import org.junit.Test;
  * Tests {@link DefaultUnitService}.
  * 
  * @author Barry DeZonia
+ * @author Curtis Rueden
+ * @author Kyle Harrington
+ * @author Ulrik Günther
  */
 public class DefaultUnitServiceTest {
 


### PR DESCRIPTION
This PR takes care that the Unicode sequence for `µ`, `\u00b5`, is correctly replaced for both uppercase and lowercase `b` (which bit us in scenerygraphics/sciview#350).
It also adds missing authors to DefaultUnitService and DefaultUnitServiceTests.