### PR TITLE
Fix ColorTable index computation

### DIFF
--- a/src/main/java/net/imagej/display/DefaultDatasetView.java
+++ b/src/main/java/net/imagej/display/DefaultDatasetView.java
@@ -216,12 +216,12 @@ public class DefaultDatasetView extends AbstractDataView implements DatasetView
 
 				// Attempt to use the ColorTables attached to our ImgPlus
 				if (imgPlus != null) {
-					int planeIndex = 1;
+					int channelStride = 1;
 					for (int i=2; i<imgPlus.dimensionIndex(Axes.CHANNEL); i++) {
-						planeIndex *= imgPlus.dimension(i);
+						channelStride *= imgPlus.dimension(i);
 					}
-					planeIndex = planeIndex + c - 1;
 
+					int planeIndex = c * channelStride;
 					if (planeIndex < imgPlus.getColorTableCount()) ct =
 						imgPlus.getColorTable(planeIndex);
 				}


### PR DESCRIPTION
The buggy version probably slipped in because it "accidentally works" if either
- the channel order is XYC..., or
- there are no more than 2 channels and all planes/timepoints for a
  channel share the same color table.