### PR TITLE
Add converters for Dataset to DatasetView and RAI to ImageDisplay

### DIFF
--- a/src/main/java/net/imagej/convert/DatasetToDatasetViewConverter.java
+++ b/src/main/java/net/imagej/convert/DatasetToDatasetViewConverter.java
@@ -1,0 +1,81 @@
+/*-
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2022 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.convert;
+
+import net.imagej.Dataset;
+import net.imagej.display.DatasetView;
+import net.imagej.display.ImageDisplayService;
+
+import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Simple {@link Converter} for wrapping {@link Dataset}s into a
+ * {@link DatasetView} of it.
+ *
+ * @author Gabriel Selzer
+ */
+@Plugin(type = Converter.class, priority = Priority.NORMAL + 1)
+public class DatasetToDatasetViewConverter extends
+	AbstractConverter<Dataset, DatasetView>
+{
+
+	@Parameter
+	private ImageDisplayService imageDisplayService;
+
+	@Override
+	public <T> T convert(final Object o, final Class<T> aClass) {
+		if (!(o instanceof Dataset)) {
+			throw new IllegalArgumentException("Object is not a Dataset");
+		}
+		final Dataset ds = (Dataset) o;
+		final DatasetView view = imageDisplayService.createDatasetView(ds);
+		if (!aClass.isInstance(view)) {
+			throw new IllegalArgumentException("Class " + aClass.getName() +
+				" is incompatible with converted DatasetView.");
+		}
+		@SuppressWarnings("unchecked")
+		final T result = (T) view;
+		return result;
+	}
+
+	@Override
+	public Class<Dataset> getInputType() {
+		return Dataset.class;
+	}
+
+	@Override
+	public Class<DatasetView> getOutputType() {
+		return DatasetView.class;
+	}
+}

--- a/src/main/java/net/imagej/convert/RAIToImageDisplayConverter.java
+++ b/src/main/java/net/imagej/convert/RAIToImageDisplayConverter.java
@@ -1,0 +1,108 @@
+/*-
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2022 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.convert;
+
+import net.imagej.Dataset;
+import net.imagej.DatasetService;
+import net.imagej.ImgPlus;
+import net.imagej.display.ImageDisplay;
+import net.imagej.display.ImageDisplayService;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.Type;
+import net.imglib2.util.Util;
+
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This {@code Converter} converts an {@code RandomAccessibleInterval} to an
+ * {@code ImageDisplay}. The pixel values will be the labels of the result
+ * {@code ImgLabeling}.
+ *
+ * @author Gabriel Selzer
+ */
+@SuppressWarnings("rawtypes")
+@Plugin(type = Converter.class)
+public class RAIToImageDisplayConverter extends
+	AbstractConverter<RandomAccessibleInterval, ImageDisplay> {
+
+	@Parameter
+	private DatasetService datasetService	;
+
+	@Parameter
+	private ImageDisplayService imageDisplayService	;
+
+	@Override
+	public <T> T convert(final Object o, final Class<T> aClass) {
+		if (!(o instanceof RandomAccessibleInterval)) {
+			throw new IllegalArgumentException(
+				"Object is not a RandomAccessibleInterval");
+		}
+		final RandomAccessibleInterval<?> rai = (RandomAccessibleInterval<?>) o;
+		Object t = Util.getTypeFromInterval(rai);
+		if (!(t instanceof Type)) {
+			throw new IllegalArgumentException("Image type is not a Type");
+		}
+		@SuppressWarnings("unchecked")
+		final Dataset dataset = raiToDataset((RandomAccessibleInterval) rai);
+		final ImageDisplay imageDisplay = //
+			imageDisplayService.createImageDisplay(dataset);
+		if (!aClass.isInstance(imageDisplay)) {
+			throw new IllegalArgumentException("Class " + aClass.getName() +
+				" is incompatible with converted ImageDisplay.");
+		}
+		@SuppressWarnings("unchecked")
+		final T result = (T) imageDisplay;
+		return result;
+	}
+
+	@Override
+	public Class<ImageDisplay> getOutputType() {
+		return ImageDisplay.class;
+	}
+
+	@Override
+	public Class<RandomAccessibleInterval> getInputType() {
+		return RandomAccessibleInterval.class;
+	}
+
+	private <T extends Type<T>> Dataset raiToDataset(
+		final RandomAccessibleInterval<T> rai)
+	{
+		if (rai instanceof Dataset) return (Dataset) rai;
+		if (rai instanceof ImgPlus) {
+			final ImgPlus<T> imgPlus = (ImgPlus<T>) rai;
+			return datasetService.create(imgPlus);
+		}
+		return datasetService.create(rai);
+	}
+}

--- a/src/main/java/net/imagej/display/ImageDisplayService.java
+++ b/src/main/java/net/imagej/display/ImageDisplayService.java
@@ -36,6 +36,7 @@ import net.imagej.Dataset;
 import net.imagej.ImageJService;
 import net.imagej.Position;
 
+import org.scijava.display.Display;
 import org.scijava.display.DisplayService;
 import org.scijava.event.EventService;
 import org.scijava.plugin.PluginService;
@@ -57,6 +58,94 @@ public interface ImageDisplayService extends ImageJService {
 
 	/** Creates a new {@link DataView} wrapping the given data object. */
 	DataView createDataView(Data data);
+
+	/** Creates a new {@link DatasetView} wrapping the given dataset. */
+	default DatasetView createDatasetView(final Dataset dataset) {
+		DataView dataView = createDataView(dataset);
+		if (!(dataView instanceof DatasetView)) {
+			throw new IllegalStateException("Wrapped DataView is a " + //
+				dataView.getClass().getName() + ", not a DatasetView. There might " +
+				"be a rogue DataView plugin wrapping Datasets inappropriately.");
+		}
+		return (DatasetView) dataView;
+	}
+
+	/**
+	 * Creates an {@link ImageDisplay} for the given data object. This is a more
+	 * specific type-safe version of {@link DisplayService#createDisplay(Object)}.
+	 * 
+	 * @param data The data object for which a display should be created. The
+	 *          object is wrapped to a {@link DataView} and added to a new
+	 *          {@link ImageDisplay}.
+	 * @return Newly created {@link ImageDisplay} containing the given data
+	 *         object.
+	 * @see DisplayService#createDisplay(Object)
+	 */
+	default ImageDisplay createImageDisplay(Data data) {
+		return createImageDisplay(null, data);
+	}
+
+	/**
+	 * Creates an {@link ImageDisplay} for the given data object. This is a more
+	 * specific type-safe version of {@link DisplayService#createDisplay(Object)}.
+	 * 
+	 * @param name The name to be assigned to the display.
+	 * @param data The data object for which a display should be created. The
+	 *          object is wrapped to a {@link DataView} and added to the new
+	 *          {@link ImageDisplay}.
+	 * @return Newly created {@link ImageDisplay} containing the given data
+	 *         object.
+	 * @see DisplayService#createDisplay(String, Object)
+	 */
+	default ImageDisplay createImageDisplay(final String name, final Data data) {
+		final Display<?> display = getDisplayService().createDisplay(name, data);
+		if (!(display instanceof ImageDisplay)) {
+			throw new IllegalStateException("Created Display is a " + //
+				display.getClass().getName() + ", not an ImageDisplay. There might " +
+				"be a rogue Display plugin wrapping DataViews inappropriately.");
+		}
+		return (ImageDisplay) display;
+	}
+
+	/**
+	 * Creates an {@link ImageDisplay} for the given {@link DataView}. This is a
+	 * more specific type-safe version of
+	 * {@link DisplayService#createDisplay(Object)}.
+	 * 
+	 * @param dataView The {@link DataView} for which a display should be created.
+	 *          The view is added to the new {@link ImageDisplay}.
+	 * @return Newly created {@link ImageDisplay} containing the given
+	 *         {@link DataView}.
+	 * @see DisplayService#createDisplay(Object)
+	 */
+	default ImageDisplay createImageDisplay(final DataView dataView) {
+		return createImageDisplay(null, dataView);
+	}
+
+	/**
+	 * Creates an {@link ImageDisplay} for the given {@link DataView}. This is a
+	 * more specific type-safe version of
+	 * {@link DisplayService#createDisplay(Object)}.
+	 * 
+	 * @param name The name to be assigned to the display.
+	 * @param dataView The {@link DataView} for which a display should be created.
+	 *          The view is added to the new {@link ImageDisplay}.
+	 * @return Newly created {@link ImageDisplay} containing the given
+	 *         {@link DataView}.
+	 * @see DisplayService#createDisplay(Object)
+	 */
+	default ImageDisplay createImageDisplay(final String name,
+		final DataView dataView)
+	{
+		final Display<?> display = //
+			getDisplayService().createDisplay(name, dataView);
+		if (!(display instanceof ImageDisplay)) {
+			throw new IllegalStateException("Created Display is a " + //
+				display.getClass().getName() + ", not an ImageDisplay. There might " +
+				"be a rogue Display plugin wrapping DataViews inappropriately.");
+		}
+		return (ImageDisplay) display;
+	}
 
 	/**
 	 * Gets the list of available {@link DataView}s. The list will contain one

--- a/src/test/java/net/imagej/convert/DatasetToDatasetViewConverterTest.java
+++ b/src/test/java/net/imagej/convert/DatasetToDatasetViewConverterTest.java
@@ -1,0 +1,81 @@
+/*-
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2022 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.convert;
+
+import net.imagej.Dataset;
+import net.imagej.DatasetService;
+import net.imagej.display.DatasetView;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.convert.ConvertService;
+
+/**
+ * A simple test ensuring {@link DatasetToDatasetViewConverter}
+ * functionality.
+ * 
+ * @author Gabriel Selzer
+ */
+public class DatasetToDatasetViewConverterTest {
+
+	private Context ctx;
+	private ConvertService convertService;
+	private DatasetService datasetService;
+
+	@Before
+	public void setUp() {
+		ctx = new Context();
+		convertService = ctx.service(ConvertService.class);
+		datasetService = ctx.service(DatasetService.class);
+	}
+
+	@After
+	public void tearDown() {
+		ctx.dispose();
+		convertService = null;
+		datasetService = null;
+	}
+
+	@Test
+	public void testDatasetToDatasetViewTest() {
+		RandomAccessibleInterval<UnsignedByteType> rai = ArrayImgs.unsignedBytes(10,
+			10, 10);
+		Dataset d = datasetService.create(rai);
+		DatasetView view = convertService.convert(d, DatasetView.class);
+		Assert.assertEquals(d, view.getData());
+	}
+
+}

--- a/src/test/java/net/imagej/convert/RAIToImageDisplayConverterTest.java
+++ b/src/test/java/net/imagej/convert/RAIToImageDisplayConverterTest.java
@@ -1,0 +1,91 @@
+/*-
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2022 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.convert;
+
+import static org.junit.Assert.assertNotNull;
+
+import net.imagej.Dataset;
+import net.imagej.DatasetService;
+import net.imagej.display.ImageDisplay;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.convert.ConvertService;
+
+/**
+ * A simple test ensuring {@link RAIToImageDisplayConverter}
+ * functionality.
+ * 
+ * @author Gabriel Selzer
+ */
+public class RAIToImageDisplayConverterTest {
+
+	private Context ctx;
+	private ConvertService convertService;
+	private DatasetService datasetService;
+
+	@Before
+	public void setUp() {
+		ctx = new Context();
+		convertService = ctx.service(ConvertService.class);
+		datasetService = ctx.service(DatasetService.class);
+	}
+
+	@After
+	public void tearDown() {
+		ctx.dispose();
+		convertService = null;
+		datasetService = null;
+	}
+
+	@Test
+	public void testRAIToImageDisplay() {
+		RandomAccessibleInterval<UnsignedByteType> rai = ArrayImgs.unsignedBytes(10,
+			10, 10);
+		ImageDisplay display = convertService.convert(rai, ImageDisplay.class);
+		assertNotNull(display);
+	}
+
+	@Test
+	public void testDatasetToImageDisplay() {
+		RandomAccessibleInterval<UnsignedByteType> rai = ArrayImgs.unsignedBytes(10,
+			10, 10);
+		Dataset d = datasetService.create(rai);
+		ImageDisplay display = convertService.convert(d, ImageDisplay.class);
+		Assert.assertTrue(display.isDisplaying(d));
+	}
+
+}


### PR DESCRIPTION
This PR adds two converters that will help imagej/napari-imagej#100, along with a regression test or two for each converter.

I'm sure there are issues because I cranked them out pretty quickly and am unfamiliar with the `Service`s used, but the commit builds without passing tests.