### PR TITLE
DatasetToDatasetViewConverter: Ensure valid color tables

### DIFF
--- a/src/main/java/net/imagej/convert/DatasetToDatasetViewConverter.java
+++ b/src/main/java/net/imagej/convert/DatasetToDatasetViewConverter.java
@@ -64,6 +64,8 @@ public class DatasetToDatasetViewConverter extends
 			throw new IllegalArgumentException("Class " + aClass.getName() +
 				" is incompatible with converted DatasetView.");
 		}
+		// Ensure the view reflects the Dataset
+		view.rebuild();
 		@SuppressWarnings("unchecked")
 		final T result = (T) view;
 		return result;

--- a/src/test/java/net/imagej/convert/DatasetToDatasetViewConverterTest.java
+++ b/src/test/java/net/imagej/convert/DatasetToDatasetViewConverterTest.java
@@ -31,6 +31,7 @@ package net.imagej.convert;
 
 import net.imagej.Dataset;
 import net.imagej.DatasetService;
+import net.imagej.display.ColorTables;
 import net.imagej.display.DatasetView;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImgs;
@@ -76,6 +77,19 @@ public class DatasetToDatasetViewConverterTest {
 		Dataset d = datasetService.create(rai);
 		DatasetView view = convertService.convert(d, DatasetView.class);
 		Assert.assertEquals(d, view.getData());
+	}
+
+	/**
+	 * Ensures reasonable color tables after the conversion
+	 */
+	@Test
+	public void testDefaultColorTables() {
+		RandomAccessibleInterval<UnsignedByteType> rai = ArrayImgs.unsignedBytes(10,
+			10, 10);
+		Dataset d = datasetService.create(rai);
+		DatasetView view = convertService.convert(d, DatasetView.class);
+		Assert.assertEquals(view.getChannelCount(), view.getColorTables().size());
+		Assert.assertEquals(ColorTables.GRAYS, view.getColorTables().get(0));
 	}
 
 }


### PR DESCRIPTION
Without a call to `DatasetView.rebuild()`, calls to `getColorTables` will result in a `NullPointerException`. By making the call in the converter, we ensure that NPEs will not be encountered.