### PR TITLE
Migrate stateless DefaultImageDisplayService methods into ImageDisplayService

### DIFF
--- a/src/main/java/net/imagej/display/DefaultImageDisplayService.java
+++ b/src/main/java/net/imagej/display/DefaultImageDisplayService.java
@@ -108,45 +108,6 @@ public final class DefaultImageDisplayService extends AbstractService
 	}
 
 	@Override
-	public Dataset getActiveDataset() {
-		return getActiveDataset(getActiveImageDisplay());
-	}
-
-	@Override
-	public DatasetView getActiveDatasetView() {
-		return getActiveDatasetView(getActiveImageDisplay());
-	}
-	
-	@Override
-	public Position getActivePosition() {
-		return getActivePosition(getActiveImageDisplay());
-	}
-
-	@Override
-	public Dataset getActiveDataset(final ImageDisplay display) {
-		final DatasetView activeDatasetView = getActiveDatasetView(display);
-		return activeDatasetView == null ? null : activeDatasetView.getData();
-	}
-
-	@Override
-	public DatasetView getActiveDatasetView(final ImageDisplay display) {
-		if (display == null) return null;
-		final DataView activeView = display.getActiveView();
-		if (activeView instanceof DatasetView) {
-			return (DatasetView) activeView;
-		}
-		return null;
-	}
-	
-	@Override
-	public Position getActivePosition(final ImageDisplay display) {
-		if (display == null) return null;
-		final DatasetView activeDatasetView = this.getActiveDatasetView(display);
-		if(activeDatasetView == null) return null;
-		return activeDatasetView.getPlanePosition();
-	}
-
-	@Override
 	public List<ImageDisplay> getImageDisplays() {
 		return displayService.getDisplaysOfType(ImageDisplay.class);
 	}

--- a/src/main/java/net/imagej/display/ImageDisplayService.java
+++ b/src/main/java/net/imagej/display/ImageDisplayService.java
@@ -161,30 +161,47 @@ public interface ImageDisplayService extends ImageJService {
 	 * Gets the active {@link Dataset}, if any, of the currently active
 	 * {@link ImageDisplay}.
 	 */
-	Dataset getActiveDataset();
+	default Dataset getActiveDataset() {
+		return getActiveDataset(getActiveImageDisplay());
+	}
 
 	/**
 	 * Gets the active {@link DatasetView}, if any, of the currently active
 	 * {@link ImageDisplay}.
 	 */
-	DatasetView getActiveDatasetView();
+	default DatasetView getActiveDatasetView() {
+		return getActiveDatasetView(getActiveImageDisplay());
+	}
 	
 	/** 
 	 * Gets the active {@link Position}, if any, of the currently active
 	 * {@link ImageDisplay}.
 	 */
-	Position getActivePosition();
+	default Position getActivePosition() {
+		return getActivePosition(getActiveImageDisplay());
+	}
 
 	/**
 	 * Gets the active {@link Dataset}, if any, of the given {@link ImageDisplay}.
 	 */
-	Dataset getActiveDataset(ImageDisplay display);
+	default Dataset getActiveDataset(ImageDisplay display)
+	{
+		final DatasetView activeDatasetView = getActiveDatasetView( display );
+		return activeDatasetView == null ? null : activeDatasetView.getData();
+	}
 
 	/**
 	 * Gets the active {@link DatasetView}, if any, of the given
 	 * {@link ImageDisplay}.
 	 */
-	DatasetView getActiveDatasetView(ImageDisplay display);
+	default DatasetView getActiveDatasetView(ImageDisplay display) {
+		if (display == null) return null;
+		final DataView activeView = display.getActiveView();
+		if (activeView instanceof DatasetView) {
+			return (DatasetView) activeView;
+		}
+		return null;
+	}
 
 	/** Gets a list of all available {@link ImageDisplay}s. */
 	List<ImageDisplay> getImageDisplays();
@@ -193,6 +210,11 @@ public interface ImageDisplayService extends ImageJService {
 	 * Gets the active {@link Position}, if any, of the active
 	 * {@link DatasetView} in the given {@link ImageDisplay}.
 	 */
-	Position getActivePosition(ImageDisplay display);
+	default Position getActivePosition(ImageDisplay display) {
+		if (display == null) return null;
+		final DatasetView activeDatasetView = this.getActiveDatasetView(display);
+		if(activeDatasetView == null) return null;
+		return activeDatasetView.getPlanePosition();
+	}
 
 }


### PR DESCRIPTION
As @ctrueden and I discussed in person this morning, these methods have no state, meaning they can be migrated into the interface without breaking backwards compatibility.